### PR TITLE
Add GitHub Actions build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code and submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Enable universe repository
+        run: sudo add-apt-repository universe
+
+      - name: Update apt and install SDL dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxi-dev libxinerama-dev libwayland-dev libwayland-egl-backend-dev libdbus-1-dev libudev-dev libgles2-mesa-dev libdrm-dev libgbm-dev libasound2-dev
+
+      - name: Grant execution permission on build script
+        run: chmod +x build.sh
+
+      - name: Run build script
+        run: ./build.sh Release
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: deadlocked-binary
+          path: build/deadlocked


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that kicks off on every push and PR. It checks out the code (with submodules), sets up the needed SDL2 dependencies, runs the build script, and then uploads the built binary as an artifact.

Basically, this automates building the project so we don’t have to do it manually every time — super handy for testing and sharing builds quickly.