### PR TITLE
Fix for game update, grab entity identity size at runtime

### DIFF
--- a/src/cs2/mod.rs
+++ b/src/cs2/mod.rs
@@ -183,7 +183,6 @@ impl Game for CS2 {
             } else {
                 data.players.push(player_data);
             }
-
         }
 
         let local_player_data = PlayerData {
@@ -222,7 +221,6 @@ impl Game for CS2 {
             false
         };
         data.wallhack_active = self.esp_enabled(config);
-
 
         for (spectator_name, spectator_id, target_id) in dead_spectators {
             data.spectators.push((spectator_id, target_id));
@@ -482,6 +480,9 @@ impl CS2 {
         offsets.planted_c4.is_ticking = client.get("C_PlantedC4", "m_bBombTicking")?;
         offsets.planted_c4.blow_time = client.get("C_PlantedC4", "m_flC4Blow")?;
         offsets.planted_c4.being_defused = client.get("C_PlantedC4", "m_bBeingDefused")?;
+
+        offsets.entity_identity.size = client.get_class("CEntityIdentity")?.size();
+        println!("ident size: {}", offsets.entity_identity.size);
 
         log::debug!("offsets: {:?} ({:?})", offsets, Instant::now() - start);
         Some(offsets)

--- a/src/cs2/offsets.rs
+++ b/src/cs2/offsets.rs
@@ -131,6 +131,11 @@ pub struct PlantedC4Offsets {
 }
 
 #[derive(Debug, Default)]
+pub struct EntityIdentityOffsets {
+    pub size: i32,
+}
+
+#[derive(Debug, Default)]
 pub struct Offsets {
     pub library: LibraryOffsets,
     pub interface: InterfaceOffsets,
@@ -148,4 +153,5 @@ pub struct Offsets {
     pub observer_services: ObserverServicesOffsets,
     pub weapon: WeaponOffsets,
     pub planted_c4: PlantedC4Offsets,
+    pub entity_identity: EntityIdentityOffsets,
 }

--- a/src/cs2/player.rs
+++ b/src/cs2/player.rs
@@ -52,15 +52,19 @@ impl Player {
     }
 
     pub fn get_client_entity(cs2: &CS2, index: u64) -> Option<u64> {
+        let bucket_index = index >> 9;
+        let index_in_bucket = index & 0x1FF;
         // wtf is this doing, and how?
         let v1: u64 = cs2
             .process
-            .read(cs2.offsets.interface.entity + 0x08 * (index >> 9) + 0x10);
+            .read(cs2.offsets.interface.entity + 0x08 * bucket_index + 0x10);
         if v1 == 0 {
             return None;
         }
         // what?
-        let entity = cs2.process.read(v1 + 112 * (index & 0x1ff));
+        let entity = cs2
+            .process
+            .read(v1 + cs2.offsets.entity_identity.size as u64 * index_in_bucket);
         if entity == 0 {
             return None;
         }
@@ -68,16 +72,22 @@ impl Player {
     }
 
     fn get_pawn(cs2: &CS2, handle: i32) -> Option<u64> {
+        // upper bits = something irrelevant
+        let index = handle as u64 & 0x7FFF;
+        let bucket_index = index >> 9;
+        let index_in_bucket = index & 0x1FF;
         // what the fuck is this doing?
         let v2: u64 = cs2
             .process
-            .read(cs2.offsets.interface.player + 8 * ((handle as u64 & 0x7FFF) >> 9));
+            .read(cs2.offsets.interface.player + 8 * bucket_index);
         if v2 == 0 {
             return None;
         }
 
         // bit-fuckery, why is this needed exactly?
-        let entity = cs2.process.read(v2 + 120 * (handle as u64 & 0x1FF));
+        let entity = cs2
+            .process
+            .read(v2 + cs2.offsets.entity_identity.size as u64 * index_in_bucket);
         if entity == 0 {
             return None;
         }
@@ -468,7 +478,6 @@ impl CS2 {
 
         self.players.clear();
 
-
         for i in 0..=64 {
             let player = match Player::index(self, i) {
                 Some(player) => player,
@@ -483,7 +492,11 @@ impl CS2 {
                 if target_pawn == local_pawn {
                     let spectator_name = player.name(self);
                     let local_steam_id = local_player.steam_id(self);
-                    self.dead_spectators.borrow_mut().push((spectator_name, spectator_id, local_steam_id));
+                    self.dead_spectators.borrow_mut().push((
+                        spectator_name,
+                        spectator_id,
+                        local_steam_id,
+                    ));
                 }
             }
 
@@ -497,6 +510,5 @@ impl CS2 {
                 self.players.push(player);
             }
         }
-
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -98,6 +98,7 @@ impl ModuleScope {
 pub struct Class {
     name: String,
     fields: HashMap<String, u64>,
+    size: i32,
 }
 
 impl Class {
@@ -106,19 +107,24 @@ impl Class {
 
         let mut fields = HashMap::new();
         let field_count: i16 = process.read(address + 0x1C);
+        let size = process.read(address + 0x18);
         if !(0..=20000).contains(&field_count) {
-            return Self { name, fields };
+            return Self { name, fields, size };
         }
         let fields_vec: u64 = process.read(address + 0x28);
         for i in 0..field_count as u64 {
             let field = Field::new(process, fields_vec + (0x20 * i));
             fields.insert(field.name, field.offset);
         }
-        Self { name, fields }
+        Self { name, fields, size }
     }
 
     fn get(&self, field: &str) -> Option<u64> {
         self.fields.get(field).copied()
+    }
+
+    pub fn size(&self) -> i32 {
+        self.size
     }
 }
 


### PR DESCRIPTION
Added a small explainer for what is going on with the entity list, it's stored in 64 buckets as an array of 64 pointers, each of which points to an array of 512 `CEntityIdentity` objects. A handle stores the index inside a bucket (`index_in_bucket`) in its lower 9 bits, and the bucket index is stored in bits 10-15. The player list is the same.