### PR TITLE
New Bomb Defuse and Helmet related settings

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -17,6 +17,7 @@ impl Colors {
     pub const TEAL: Color32 = Color32::from_rgb(80, 200, 200);
     pub const BLUE: Color32 = Color32::from_rgb(100, 150, 240);
     pub const PURPLE: Color32 = Color32::from_rgb(180, 120, 240);
+    pub const LIGHT_BLUE: Color32 = Color32::from_rgb(0,128,255);
 
     pub const ACCENT_COLORS: [(&str, Color32); 7] = [
         ("Red", Self::RED),

--- a/src/config.rs
+++ b/src/config.rs
@@ -228,6 +228,28 @@ pub enum HelmetMode {
     Armor,
 }
 
+#[derive(Debug, Clone, PartialEq, EnumIter, Serialize, Deserialize)]
+pub enum HoriBarMode {
+    Left,
+    Centre,
+    Right,
+}
+
+#[derive(Debug, Clone, PartialEq, EnumIter, Serialize, Deserialize)]
+pub enum VertiBarMode {
+    Top,
+    Centre,
+    Bottom,
+}
+
+#[derive(Debug, Clone, PartialEq, EnumIter, Serialize, Deserialize)]
+pub enum BarLocationMode {
+    Top,
+    Right,
+    Bottom,
+    Left,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct PlayerConfig {
@@ -281,6 +303,16 @@ impl Default for PlayerConfig {
 pub struct HudConfig {
     pub bomb_mode: BombMode,
     pub defuse_mode: BombMode,
+    pub bomb_timer_location: BarLocationMode,
+    pub defuse_timer_location: BarLocationMode,
+    pub bomb_timer_end_h: HoriBarMode,
+    pub defuse_timer_end_h: HoriBarMode,
+    pub bomb_timer_end_v: VertiBarMode,
+    pub defuse_timer_end_v: VertiBarMode,
+    pub bomb_bar_colour: Color32,
+    pub defuse_bar_colour: Color32,
+    pub defuse_gradiant: bool,
+    pub bomb_gradiant: bool,
     pub fov_circle: bool,
     pub sniper_crosshair: bool,
     pub crosshair_color: Color32,
@@ -305,6 +337,16 @@ impl Default for HudConfig {
         Self {
             bomb_mode: BombMode::Both,
             defuse_mode: BombMode::Both,
+            bomb_timer_location: BarLocationMode::Bottom,
+            defuse_timer_location: BarLocationMode::Top,
+            bomb_timer_end_h: HoriBarMode::Centre,
+            defuse_timer_end_h: HoriBarMode::Centre,
+            bomb_timer_end_v: VertiBarMode::Bottom,
+            defuse_timer_end_v: VertiBarMode::Bottom,
+            bomb_bar_colour: Color32::RED,
+            defuse_bar_colour: Color32::BLUE,
+            bomb_gradiant: true,
+            defuse_gradiant: true,
             fov_circle: false,
             sniper_crosshair: true,
             crosshair_color: Color32::WHITE,

--- a/src/config.rs
+++ b/src/config.rs
@@ -221,6 +221,13 @@ pub enum BombMode {
     Both,
 }
 
+#[derive(Debug, Clone, PartialEq, EnumIter, Serialize, Deserialize)]
+pub enum HelmetMode {
+    None,
+    Icon,
+    Armor,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct PlayerConfig {
@@ -239,6 +246,9 @@ pub struct PlayerConfig {
     pub player_name: bool,
     pub weapon_icon: bool,
     pub tags: bool,
+    pub helmet: HelmetMode,
+    pub armor_colour: Color32,
+    pub armor_nohelm_colour: Color32,
 }
 
 impl Default for PlayerConfig {
@@ -259,6 +269,9 @@ impl Default for PlayerConfig {
             player_name: true,
             weapon_icon: true,
             tags: true,
+            helmet: HelmetMode::Icon,
+            armor_colour: Color32::BLUE,
+            armor_nohelm_colour: Color32::CYAN,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -213,6 +213,14 @@ pub enum BoxMode {
     Full,
 }
 
+#[derive(Debug, Clone, PartialEq, EnumIter, Serialize, Deserialize)]
+pub enum BombMode {
+    None,
+    Timer,
+    Bar,
+    Both,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct PlayerConfig {
@@ -258,7 +266,8 @@ impl Default for PlayerConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct HudConfig {
-    pub bomb_timer: bool,
+    pub bomb_mode: BombMode,
+    pub defuse_mode: BombMode,
     pub fov_circle: bool,
     pub sniper_crosshair: bool,
     pub crosshair_color: Color32,
@@ -281,7 +290,8 @@ pub struct HudConfig {
 impl Default for HudConfig {
     fn default() -> Self {
         Self {
-            bomb_timer: true,
+            bomb_mode: BombMode::Both,
+            defuse_mode: BombMode::Both,
             fov_circle: false,
             sniper_crosshair: true,
             crosshair_color: Color32::WHITE,

--- a/src/config.rs
+++ b/src/config.rs
@@ -271,7 +271,7 @@ impl Default for PlayerConfig {
             tags: true,
             helmet: HelmetMode::Icon,
             armor_colour: Color32::BLUE,
-            armor_nohelm_colour: Color32::CYAN,
+            armor_nohelm_colour: Color32::LIGHT_BLUE,
         }
     }
 }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -772,7 +772,7 @@ impl App {
                 }
             });
 
-            egui::ComboBox::new("defuse_mode", "Defuser")
+            egui::ComboBox::new("defuse_mode", "Defuse")
             .selected_text(format!("{:?}", self.config.hud.defuse_mode))
             .show_ui(ui, |ui| {
                 for mode in BombMode::iter() {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -14,7 +14,8 @@ use crate::{
     color::Colors,
     config::{
         AimbotConfig, BoxMode, CONFIG_PATH, Config, DrawMode, TargetingMode, TriggerbotMode,
-        VERSION, WeaponConfig, available_configs, delete_config, parse_config, write_config, BombMode,
+        VERSION, WeaponConfig, available_configs, delete_config, parse_config, write_config,
+        BombMode, HelmetMode,
     },
     constants::cs2,
     cs2::{
@@ -531,6 +532,18 @@ impl App {
                         self.config.player.skeleton_color = color;
                         self.send_config();
                     }
+                    if let Some(color) =
+                        self.color_picker(ui, &self.config.player.armor_colour, "Armor Bar")
+                    {
+                        self.config.player.armor_colour = color;
+                        self.send_config();
+                    }
+                    if let Some(color) =
+                        self.color_picker(ui, &self.config.player.armor_nohelm_colour, "Armor Bar (No Helmet)")
+                    {
+                        self.config.player.armor_nohelm_colour = color;
+                        self.send_config();
+                    }
 
                     ui.horizontal(|ui| {
                         if ui
@@ -660,6 +673,19 @@ impl App {
             {
                 self.send_config();
             }
+            egui::ComboBox::new("helmet", "Helmet")
+            .selected_text(format!("{:?}", self.config.player.helmet))
+            .show_ui(ui, |ui| {
+                for mode in HelmetMode::iter() {
+                    let text = format!("{:?}", &mode);
+                    if ui
+                        .selectable_value(&mut self.config.player.helmet, mode, text)
+                        .clicked()
+                        {
+                            self.send_config();
+                        }
+                }
+            });
         });
     }
 
@@ -752,12 +778,6 @@ impl App {
 
     fn hud_left(&mut self, ui: &mut Ui) {
         collapsing_open(ui, "HUD", |ui| {
-            /*if ui
-                .checkbox(&mut self.config.hud.bomb_timer, "Bomb Timer")
-                .changed()
-            {
-                self.send_config();
-            }*/
             egui::ComboBox::new("bomb_mode", "Bomb")
             .selected_text(format!("{:?}", self.config.hud.bomb_mode))
             .show_ui(ui, |ui| {
@@ -1572,7 +1592,13 @@ impl App {
                     pos2(x, bl.y),
                     pos2(x, bl.y - (delta * player.armor as f32 / 100.0)),
                 ],
-                Stroke::new(self.config.hud.line_width, self.apply_alpha(Color32::BLUE)),
+                if !player.has_helmet && self.config.player.helmet == HelmetMode::Armor{
+                    Stroke::new(self.config.hud.line_width, self.apply_alpha(self.config.player.armor_nohelm_colour))
+                } else {
+                    Stroke::new(self.config.hud.line_width, self.apply_alpha(self.config.player.armor_colour))
+
+                }
+
             );
         }
 
@@ -1601,7 +1627,7 @@ impl App {
             offset += font_size;
         }
 
-        if self.config.player.tags && player.has_helmet {
+        if self.config.player.helmet == HelmetMode::Icon && player.has_helmet {
             painter.text(
                 pos2(tr.x + ew, tr.y + offset),
                 Align2::LEFT_TOP,

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1509,7 +1509,7 @@ impl App {
                     if let Some(pos) = world_to_screen(&data.bomb.position, data) {
                         self.text(
                             &painter,
-                            format!("defusing {:.3}", data.bomb.defuse_remain_time),
+                            format!("{:.3}", data.bomb.defuse_remain_time),
                                 pos2(pos.x, pos.y + self.config.hud.font_size),
                                 Align2::CENTER_CENTER,
                                 None,
@@ -1528,18 +1528,35 @@ impl App {
                     }
                     let mut p1 = 0.0; let mut p2 = 0.0;
                     let mut p3 = 0.0; let mut p4 = 0.0;
-                    if self.config.hud.defuse_timer_location == BarLocationMode::Bottom {
-                        p3 = data.window_size.y;
-                        p4 = data.window_size.y;
-                    } else if self.config.hud.defuse_timer_location == BarLocationMode::Top {
-                        p3 = 0.0;
-                        p4 = 0.0;
-                    } else if self.config.hud.defuse_timer_location == BarLocationMode::Left {
-                        p1 = 0.0;
-                        p2 = 0.0;
-                    } else { //right
-                        p1 = data.window_size.x;
-                        p2 = data.window_size.x;
+                    if (self.config.hud.bomb_mode == BombMode::Bar || self.config.hud.bomb_mode == BombMode::Both) &&
+                    (self.config.hud.defuse_timer_location == self.config.hud.bomb_timer_location) {
+                        if self.config.hud.defuse_timer_location == BarLocationMode::Bottom {
+                            p3 = data.window_size.y-(self.config.hud.line_width * 2.25);
+                            p4 = data.window_size.y-(self.config.hud.line_width * 2.25);
+                        } else if self.config.hud.defuse_timer_location == BarLocationMode::Top {
+                            p3 = self.config.hud.line_width * 2.25;
+                            p4 = self.config.hud.line_width * 2.25;
+                        } else if self.config.hud.defuse_timer_location == BarLocationMode::Left {
+                            p1 = self.config.hud.line_width * 2.25;
+                            p2 = self.config.hud.line_width * 2.25;
+                        } else { //right
+                            p1 = data.window_size.x-(self.config.hud.line_width * 2.25);
+                            p2 = data.window_size.x-(self.config.hud.line_width * 2.25);
+                        }
+                    } else {
+                        if self.config.hud.defuse_timer_location == BarLocationMode::Bottom {
+                            p3 = data.window_size.y;
+                            p4 = data.window_size.y;
+                        } else if self.config.hud.defuse_timer_location == BarLocationMode::Top {
+                            p3 = 0.0;
+                            p4 = 0.0;
+                        } else if self.config.hud.defuse_timer_location == BarLocationMode::Left {
+                            p1 = 0.0;
+                            p2 = 0.0;
+                        } else { //right
+                            p1 = data.window_size.x;
+                            p2 = data.window_size.x;
+                        }
                     } if self.config.hud.defuse_timer_location == BarLocationMode::Top || self.config.hud.defuse_timer_location == BarLocationMode::Bottom {
                         if self.config.hud.defuse_timer_end_h == HoriBarMode::Centre {
                             p1 = (data.window_size.x/2.0)-((data.window_size.x * fraction)/2.0);
@@ -1563,14 +1580,7 @@ impl App {
                             p4 = data.window_size.y;
                         }
                     }
-                    painter.line(
-                        vec![
-                            pos2(p1, p3),
-                            pos2(p2, p4),
-                        ],
-                        Stroke::new(self.config.hud.line_width * 3.0, color),
-                    );
-
+                    painter.line(vec![pos2(p1, p3), pos2(p2, p4),], Stroke::new(self.config.hud.line_width * 1.5, color));
                 }
             }
         }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -538,11 +538,13 @@ impl App {
                         self.config.player.armor_colour = color;
                         self.send_config();
                     }
-                    if let Some(color) =
-                        self.color_picker(ui, &self.config.player.armor_nohelm_colour, "Armor Bar (No Helmet)")
-                    {
-                        self.config.player.armor_nohelm_colour = color;
-                        self.send_config();
+                    if self.config.player.helmet == HelmetMode::Armor {
+                        if let Some(color) =
+                            self.color_picker(ui, &self.config.player.armor_nohelm_colour, "Armor Bar (No Helmet)")
+                        {
+                            self.config.player.armor_nohelm_colour = color;
+                            self.send_config();
+                        }
                     }
 
                     ui.horizontal(|ui| {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -744,65 +744,63 @@ impl App {
                             self.send_config();
                         }
                     }
-
                 });
-            });
 
-        collapsing_open(ui, "Grenade Trails", |ui| {
-            if ui
-                .checkbox(&mut self.config.hud.grenade_trails, "Grenade Trails")
-                .changed()
-            {
-                self.send_config();
-            }
+                collapsing_open(ui, "Grenade Trails", |ui| {
+                    if ui
+                    .checkbox(&mut self.config.hud.grenade_trails, "Grenade Trails")
+                    .changed()
+                    {
+                        self.send_config();
+                    }
 
-            if let Some(color) =
-                self.color_picker(ui, &self.config.hud.smoke_trail_color, "Smoke Trail Color")
-            {
-                self.config.hud.smoke_trail_color = color;
-                self.send_config();
-            }
+                    if let Some(color) =
+                    self.color_picker(ui, &self.config.hud.smoke_trail_color, "Smoke Trail Color")
+                    {
+                        self.config.hud.smoke_trail_color = color;
+                        self.send_config();
+                    }
 
-            if let Some(color) = self.color_picker(
-                ui,
-                &self.config.hud.molotov_trail_color,
-                "Molotov Trail Color",
-            ) {
-                self.config.hud.molotov_trail_color = color;
-                self.send_config();
-            }
+                    if let Some(color) = self.color_picker(
+                        ui,
+                        &self.config.hud.molotov_trail_color,
+                        "Molotov Trail Color",
+                    ) {
+                        self.config.hud.molotov_trail_color = color;
+                        self.send_config();
+                    }
 
-            if let Some(color) = self.color_picker(
-                ui,
-                &self.config.hud.incendiary_trail_color,
-                "Incendiary Trail Color",
-            ) {
-                self.config.hud.incendiary_trail_color = color;
-                self.send_config();
-            }
+                    if let Some(color) = self.color_picker(
+                        ui,
+                        &self.config.hud.incendiary_trail_color,
+                        "Incendiary Trail Color",
+                    ) {
+                        self.config.hud.incendiary_trail_color = color;
+                        self.send_config();
+                    }
 
-            if let Some(color) =
-                self.color_picker(ui, &self.config.hud.flash_trail_color, "Flash Trail Color")
-            {
-                self.config.hud.flash_trail_color = color;
-                self.send_config();
-            }
+                    if let Some(color) =
+                    self.color_picker(ui, &self.config.hud.flash_trail_color, "Flash Trail Color")
+                    {
+                        self.config.hud.flash_trail_color = color;
+                        self.send_config();
+                    }
 
-            if let Some(color) = self.color_picker(
-                ui,
-                &self.config.hud.he_trail_color,
-                "HE Grenade Trail Color",
-            ) {
-                self.config.hud.he_trail_color = color;
-                self.send_config();
-            }
-
-            if let Some(color) =
-                self.color_picker(ui, &self.config.hud.decoy_trail_color, "Decoy Trail Color")
-            {
-                self.config.hud.decoy_trail_color = color;
-                self.send_config();
-            }
+                    if let Some(color) = self.color_picker(
+                        ui,
+                        &self.config.hud.he_trail_color,
+                        "HE Grenade Trail Color",
+                    ) {
+                        self.config.hud.he_trail_color = color;
+                        self.send_config();
+                    }
+                    if let Some(color) =
+                    self.color_picker(ui, &self.config.hud.decoy_trail_color, "Decoy Trail Color")
+                    {
+                        self.config.hud.decoy_trail_color = color;
+                        self.send_config();
+                    }
+                });
         });
     }
 

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -15,7 +15,7 @@ use crate::{
     config::{
         AimbotConfig, BoxMode, CONFIG_PATH, Config, DrawMode, TargetingMode, TriggerbotMode,
         VERSION, WeaponConfig, available_configs, delete_config, parse_config, write_config,
-        BombMode, HelmetMode,
+        BombMode, HelmetMode, HoriBarMode, VertiBarMode, BarLocationMode,
     },
     constants::cs2,
     cs2::{
@@ -532,11 +532,21 @@ impl App {
                         self.config.player.skeleton_color = color;
                         self.send_config();
                     }
-                    if let Some(color) =
-                        self.color_picker(ui, &self.config.player.armor_colour, "Armor Bar")
-                    {
-                        self.config.player.armor_colour = color;
-                        self.send_config();
+                    if self.config.player.helmet == HelmetMode::Armor {
+                        if let Some(color) =
+                            self.color_picker(ui, &self.config.player.armor_colour, "Armor Bar (Has Helmet)")
+                        {
+                            self.config.player.armor_colour = color;
+                            self.send_config();
+                        }
+                    } else {
+                        if let Some(color) =
+                            self.color_picker(ui, &self.config.player.armor_colour, "Armor Bar")
+                            {
+                                self.config.player.armor_colour = color;
+                                self.send_config();
+                            }
+
                     }
                     if self.config.player.helmet == HelmetMode::Armor {
                         if let Some(color) =
@@ -717,6 +727,24 @@ impl App {
                         self.config.hud.crosshair_color = color;
                         self.send_config();
                     }
+
+                    if !self.config.hud.bomb_gradiant {
+                        if let Some(color) =
+                        self.color_picker(ui, &self.config.hud.bomb_bar_colour, "Bomb Bar Colour")
+                        {
+                            self.config.hud.bomb_bar_colour = color;
+                            self.send_config();
+                        }
+                    }
+                    if !self.config.hud.defuse_gradiant  {
+                        if let Some(color) =
+                        self.color_picker(ui, &self.config.hud.defuse_bar_colour, "Defuse Bar Colour")
+                        {
+                            self.config.hud.defuse_bar_colour = color;
+                            self.send_config();
+                        }
+                    }
+
                 });
             });
 
@@ -807,7 +835,22 @@ impl App {
                         }
                 }
             });
-
+            if self.config.hud.bomb_mode == BombMode::Timer || self.config.hud.bomb_mode == BombMode::Both {
+                if ui
+                .checkbox(&mut self.config.hud.bomb_gradiant, "Bomb Bar Grandiant")
+                .changed()
+                {
+                    self.send_config();
+                }
+            }
+            if self.config.hud.defuse_mode == BombMode::Timer || self.config.hud.defuse_mode == BombMode::Both {
+                if ui
+                .checkbox(&mut self.config.hud.defuse_gradiant, "Defuse Bar Gradiant")
+                .changed()
+                {
+                    self.send_config();
+                }
+            }
             if ui
                 .checkbox(&mut self.config.hud.fov_circle, "FOV Circle")
                 .changed()
@@ -876,6 +919,96 @@ impl App {
                 }
                 ui.label("Font Size");
             });
+            if self.config.hud.bomb_mode == BombMode::Timer || self.config.hud.bomb_mode == BombMode::Both {
+                egui::ComboBox::new("bomb_timer_location", "Bomb timer location")
+                .selected_text(format!("{:?}", self.config.hud.bomb_timer_location))
+                .show_ui(ui, |ui| {
+                    for mode in BarLocationMode::iter() {
+                        let text = format!("{:?}", &mode);
+                        if ui
+                            .selectable_value(&mut self.config.hud.bomb_timer_location, mode, text)
+                            .clicked()
+                            {
+                                self.send_config();
+                            }
+                    }
+                });
+            }
+            if (self.config.hud.bomb_mode == BombMode::Timer || self.config.hud.bomb_mode == BombMode::Both) &&
+            (self.config.hud.bomb_timer_location == BarLocationMode::Top || self.config.hud.bomb_timer_location == BarLocationMode::Bottom) {
+                egui::ComboBox::new("bomb_timer_end_h", "Bomb timer end")
+                .selected_text(format!("{:?}", self.config.hud.bomb_timer_end_h))
+                .show_ui(ui, |ui| {
+                    for mode in HoriBarMode::iter() {
+                        let text = format!("{:?}", &mode);
+                        if ui
+                            .selectable_value(&mut self.config.hud.bomb_timer_end_h, mode, text)
+                            .clicked()
+                            {
+                                self.send_config();
+                            }
+                    }
+                });
+            } else if self.config.hud.bomb_mode == BombMode::Timer || self.config.hud.bomb_mode == BombMode::Both {
+                egui::ComboBox::new("bomb_timer_end_v", "Bomb timer end")
+                .selected_text(format!("{:?}", self.config.hud.bomb_timer_end_v))
+                .show_ui(ui, |ui| {
+                    for mode in VertiBarMode::iter() {
+                        let text = format!("{:?}", &mode);
+                        if ui
+                            .selectable_value(&mut self.config.hud.bomb_timer_end_v, mode, text)
+                            .clicked()
+                            {
+                                self.send_config();
+                            }
+                    }
+                });
+            }
+            if self.config.hud.defuse_mode == BombMode::Timer || self.config.hud.defuse_mode == BombMode::Both {
+                egui::ComboBox::new("defuse_timer_location", "Defuse timer location")
+                .selected_text(format!("{:?}", self.config.hud.defuse_timer_location))
+                .show_ui(ui, |ui| {
+                    for mode in BarLocationMode::iter() {
+                        let text = format!("{:?}", &mode);
+                        if ui
+                            .selectable_value(&mut self.config.hud.defuse_timer_location, mode, text)
+                            .clicked()
+                            {
+                                self.send_config();
+                            }
+                    }
+                });
+            }
+            if (self.config.hud.defuse_mode == BombMode::Timer || self.config.hud.defuse_mode == BombMode::Both) &&
+            (self.config.hud.defuse_timer_location == BarLocationMode::Top || self.config.hud.defuse_timer_location == BarLocationMode::Bottom) {
+                egui::ComboBox::new("defuse_timer_end_h", "Defuse timer end")
+                .selected_text(format!("{:?}", self.config.hud.defuse_timer_end_h))
+                .show_ui(ui, |ui| {
+                    for mode in HoriBarMode::iter() {
+                        let text = format!("{:?}", &mode);
+                        if ui
+                            .selectable_value(&mut self.config.hud.defuse_timer_end_h, mode, text)
+                            .clicked()
+                            {
+                                self.send_config();
+                            }
+                    }
+                });
+            } else if self.config.hud.defuse_mode == BombMode::Timer || self.config.hud.defuse_mode == BombMode::Both {
+                egui::ComboBox::new("defuse_timer_end_v", "Defuse timer end")
+                .selected_text(format!("{:?}", self.config.hud.defuse_timer_end_v))
+                .show_ui(ui, |ui| {
+                    for mode in VertiBarMode::iter() {
+                        let text = format!("{:?}", &mode);
+                        if ui
+                            .selectable_value(&mut self.config.hud.defuse_timer_end_v, mode, text)
+                            .clicked()
+                            {
+                                self.send_config();
+                            }
+                    }
+                });
+            }
         });
 
         ui.collapsing("Advanced", |ui| {
@@ -1316,11 +1449,53 @@ impl App {
             if self.config.hud.bomb_mode == BombMode::Bar || self.config.hud.bomb_mode == BombMode::Both {
                 if data.bomb.planted {
                     let fraction = (data.bomb.timer / 40.0).clamp(0.0, 1.0);
-                    let color = self.apply_alpha(self.health_color((fraction * 100.0) as i32));
+                    let color;
+                    if self.config.hud.bomb_gradiant {
+                        color = self.apply_alpha(self.health_color((fraction * 100.0) as i32));
+                    } else {
+                        color = self.apply_alpha(self.config.hud.bomb_bar_colour);
+                    }
+                    let mut p1 = 0.0; let mut p2 = 0.0;
+                    let mut p3 = 0.0; let mut p4 = 0.0;
+                    if self.config.hud.bomb_timer_location == BarLocationMode::Bottom {
+                        p3 = data.window_size.y;
+                        p4 = data.window_size.y;
+                    } else if self.config.hud.bomb_timer_location == BarLocationMode::Top {
+                        p3 = 0.0;
+                        p4 = 0.0;
+                    } else if self.config.hud.bomb_timer_location == BarLocationMode::Left {
+                        p1 = 0.0;
+                        p2 = 0.0;
+                    } else { //right
+                        p1 = data.window_size.x;
+                        p2 = data.window_size.x;
+                    } if self.config.hud.bomb_timer_location == BarLocationMode::Top || self.config.hud.bomb_timer_location == BarLocationMode::Bottom {
+                        if self.config.hud.bomb_timer_end_h == HoriBarMode::Centre {
+                            p1 = (data.window_size.x/2.0)-((data.window_size.x * fraction)/2.0);
+                            p2 = (data.window_size.x/2.0)+((data.window_size.x * fraction)/2.0);
+                        } else if self.config.hud.bomb_timer_end_h == HoriBarMode::Left {
+                            p1 = 0.0;
+                            p2 = data.window_size.x*fraction;
+                        } else {//right
+                            p1 = data.window_size.x-(data.window_size.x*fraction);
+                            p2 = data.window_size.x;
+                        }
+                    } else { //left or right
+                        if self.config.hud.bomb_timer_end_v == VertiBarMode::Centre {
+                            p3 = (data.window_size.y/2.0)-((data.window_size.y * fraction)/2.0);
+                            p4 = (data.window_size.y/2.0)+((data.window_size.y * fraction)/2.0);
+                        } else if self.config.hud.bomb_timer_end_v == VertiBarMode::Top {
+                            p3 = 0.0;
+                            p4 = data.window_size.y*fraction;
+                        } else { //bottom
+                            p3 = data.window_size.y-(data.window_size.y*fraction);
+                            p4 = data.window_size.y;
+                        }
+                    }
                     painter.line(
                         vec![
-                            pos2((data.window_size.x/2.0)-((data.window_size.x * fraction)/2.0), data.window_size.y),
-                            pos2((data.window_size.x/2.0)+((data.window_size.x * fraction)/2.0), data.window_size.y),
+                            pos2(p1, p3),
+                            pos2(p2, p4),
                         ],
                         Stroke::new(self.config.hud.line_width * 3.0, color),
                     );
@@ -1345,14 +1520,57 @@ impl App {
             if self.config.hud.defuse_mode == BombMode::Bar || self.config.hud.defuse_mode == BombMode::Both {
                 if data.bomb.planted && data.bomb.being_defused {
                     let fraction = (data.bomb.defuse_remain_time / 10.0).clamp(0.0, 1.0);
-                    let color = self.apply_alpha(self.health_color((fraction * 100.0) as i32));
+                    let color;
+                    if self.config.hud.defuse_gradiant {
+                        color = self.apply_alpha(self.health_color((fraction * 100.0) as i32));
+                    } else {
+                        color = self.apply_alpha(self.config.hud.defuse_bar_colour);
+                    }
+                    let mut p1 = 0.0; let mut p2 = 0.0;
+                    let mut p3 = 0.0; let mut p4 = 0.0;
+                    if self.config.hud.defuse_timer_location == BarLocationMode::Bottom {
+                        p3 = data.window_size.y;
+                        p4 = data.window_size.y;
+                    } else if self.config.hud.defuse_timer_location == BarLocationMode::Top {
+                        p3 = 0.0;
+                        p4 = 0.0;
+                    } else if self.config.hud.defuse_timer_location == BarLocationMode::Left {
+                        p1 = 0.0;
+                        p2 = 0.0;
+                    } else { //right
+                        p1 = data.window_size.x;
+                        p2 = data.window_size.x;
+                    } if self.config.hud.defuse_timer_location == BarLocationMode::Top || self.config.hud.defuse_timer_location == BarLocationMode::Bottom {
+                        if self.config.hud.defuse_timer_end_h == HoriBarMode::Centre {
+                            p1 = (data.window_size.x/2.0)-((data.window_size.x * fraction)/2.0);
+                            p2 = (data.window_size.x/2.0)+((data.window_size.x * fraction)/2.0);
+                        } else if self.config.hud.defuse_timer_end_h == HoriBarMode::Left {
+                            p1 = 0.0;
+                            p2 = data.window_size.x*fraction;
+                        } else {//right
+                            p1 = data.window_size.x-(data.window_size.x*fraction);
+                            p2 = data.window_size.x;
+                        }
+                    } else { //left or right
+                        if self.config.hud.defuse_timer_end_v == VertiBarMode::Centre {
+                            p3 = (data.window_size.y/2.0)-((data.window_size.y * fraction)/2.0);
+                            p4 = (data.window_size.y/2.0)+((data.window_size.y * fraction)/2.0);
+                        } else if self.config.hud.bomb_timer_end_v == VertiBarMode::Top {
+                            p3 = 0.0;
+                            p4 = data.window_size.y*fraction;
+                        } else { //bottom
+                            p3 = data.window_size.y-(data.window_size.y*fraction);
+                            p4 = data.window_size.y;
+                        }
+                    }
                     painter.line(
                         vec![
-                            pos2((data.window_size.x/2.0)-((data.window_size.x * fraction)/2.0), 0.0),
-                                pos2((data.window_size.x/2.0)+((data.window_size.x * fraction)/2.0), 0.0),
+                            pos2(p1, p3),
+                            pos2(p2, p4),
                         ],
                         Stroke::new(self.config.hud.line_width * 3.0, color),
                     );
+
                 }
             }
         }
@@ -1598,9 +1816,7 @@ impl App {
                     Stroke::new(self.config.hud.line_width, self.apply_alpha(self.config.player.armor_nohelm_colour))
                 } else {
                     Stroke::new(self.config.hud.line_width, self.apply_alpha(self.config.player.armor_colour))
-
                 }
-
             );
         }
 

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -14,7 +14,7 @@ use crate::{
     color::Colors,
     config::{
         AimbotConfig, BoxMode, CONFIG_PATH, Config, DrawMode, TargetingMode, TriggerbotMode,
-        VERSION, WeaponConfig, available_configs, delete_config, parse_config, write_config,
+        VERSION, WeaponConfig, available_configs, delete_config, parse_config, write_config, BombMode,
     },
     constants::cs2,
     cs2::{
@@ -752,12 +752,39 @@ impl App {
 
     fn hud_left(&mut self, ui: &mut Ui) {
         collapsing_open(ui, "HUD", |ui| {
-            if ui
+            /*if ui
                 .checkbox(&mut self.config.hud.bomb_timer, "Bomb Timer")
                 .changed()
             {
                 self.send_config();
-            }
+            }*/
+            egui::ComboBox::new("bomb_mode", "Bomb")
+            .selected_text(format!("{:?}", self.config.hud.bomb_mode))
+            .show_ui(ui, |ui| {
+                for mode in BombMode::iter() {
+                    let text = format!("{:?}", &mode);
+                    if ui
+                        .selectable_value(&mut self.config.hud.bomb_mode, mode, text)
+                        .clicked()
+                        {
+                            self.send_config();
+                        }
+                }
+            });
+
+            egui::ComboBox::new("defuse_mode", "Defuser")
+            .selected_text(format!("{:?}", self.config.hud.defuse_mode))
+            .show_ui(ui, |ui| {
+                for mode in BombMode::iter() {
+                    let text = format!("{:?}", &mode);
+                    if ui
+                        .selectable_value(&mut self.config.hud.defuse_mode, mode, text)
+                        .clicked()
+                        {
+                            self.send_config();
+                        }
+                }
+            });
 
             if ui
                 .checkbox(&mut self.config.hud.fov_circle, "FOV Circle")
@@ -1249,35 +1276,63 @@ impl App {
             }
         }
 
-        if self.config.hud.bomb_timer && data.bomb.planted {
-            if let Some(pos) = world_to_screen(&data.bomb.position, data) {
-                self.text(
-                    &painter,
-                    format!("{:.3}", data.bomb.timer),
-                        pos,
-                        Align2::CENTER_CENTER,
-                        None,
-                );
-                if data.bomb.being_defused {
-                    self.text(
-                        &painter,
-                        format!("defusing {:.3}", data.bomb.defuse_remain_time),
-                            pos2(pos.x, pos.y + self.config.hud.font_size),
-                              Align2::CENTER_CENTER,
-                              None,
-                    );
+        if self.config.hud.bomb_mode != BombMode::None {
+            if self.config.hud.bomb_mode == BombMode::Timer || self.config.hud.bomb_mode == BombMode::Both {
+                if data.bomb.planted {
+                    if let Some(pos) = world_to_screen(&data.bomb.position, data) {
+                        self.text(
+                            &painter,
+                            format!("{:.3}", data.bomb.timer),
+                                pos,
+                                Align2::CENTER_CENTER,
+                                None,
+                        );
+                    }
                 }
             }
 
-            let fraction = (data.bomb.timer / 40.0).clamp(0.0, 1.0);
-            let color = self.apply_alpha(self.health_color((fraction * 100.0) as i32));
-            painter.line(
-                vec![
-                    pos2(0.0, data.window_size.y),
-                    pos2(data.window_size.x * fraction, data.window_size.y),
-                ],
-                Stroke::new(self.config.hud.line_width * 3.0, color),
-            );
+            if self.config.hud.bomb_mode == BombMode::Bar || self.config.hud.bomb_mode == BombMode::Both {
+                if data.bomb.planted {
+                    let fraction = (data.bomb.timer / 40.0).clamp(0.0, 1.0);
+                    let color = self.apply_alpha(self.health_color((fraction * 100.0) as i32));
+                    painter.line(
+                        vec![
+                            pos2((data.window_size.x/2.0)-((data.window_size.x * fraction)/2.0), data.window_size.y),
+                            pos2((data.window_size.x/2.0)+((data.window_size.x * fraction)/2.0), data.window_size.y),
+                        ],
+                        Stroke::new(self.config.hud.line_width * 3.0, color),
+                    );
+                }
+            }
+        }
+
+        if self.config.hud.defuse_mode != BombMode::None {
+            if self.config.hud.defuse_mode == BombMode::Timer || self.config.hud.defuse_mode == BombMode::Both {
+                if data.bomb.planted && data.bomb.being_defused {
+                    if let Some(pos) = world_to_screen(&data.bomb.position, data) {
+                        self.text(
+                            &painter,
+                            format!("defusing {:.3}", data.bomb.defuse_remain_time),
+                                pos2(pos.x, pos.y + self.config.hud.font_size),
+                                Align2::CENTER_CENTER,
+                                None,
+                        );
+                    }
+                }
+            }
+            if self.config.hud.defuse_mode == BombMode::Bar || self.config.hud.defuse_mode == BombMode::Both {
+                if data.bomb.planted && data.bomb.being_defused {
+                    let fraction = (data.bomb.defuse_remain_time / 10.0).clamp(0.0, 1.0);
+                    let color = self.apply_alpha(self.health_color((fraction * 100.0) as i32));
+                    painter.line(
+                        vec![
+                            pos2((data.window_size.x/2.0)-((data.window_size.x * fraction)/2.0), 0.0),
+                                pos2((data.window_size.x/2.0)+((data.window_size.x * fraction)/2.0), 0.0),
+                        ],
+                        Stroke::new(self.config.hud.line_width * 3.0, color),
+                    );
+                }
+            }
         }
 
         // fov circle


### PR DESCRIPTION
I added the ability to individually disabled the on bomb timer and countdown bar
I added the countdown bar to enemy defusing, the current fraction is 10, so if someone who is defusing has a kit, the bar starts halfway done
The bomb/defuse countdown bar now closes in the center rather than towards the left
Removed helmet from tags and added its own thing
It can show either nothing, the icon that is currently under Show Tags in the main branch or 'Armor', which shows the armor bar as a different colour when the enemy has no helmet
I believe that the wording changing on the colour picker explains it well enough
also there is probably a better way than an if state to change what a colour picker says, but idk what that might be