### PR TITLE
Cfg path fallback & option to use system Source2Viewer

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,5 +2,8 @@ use copy_to_output::copy_to_output;
 
 fn main() {
     println!("cargo:rerun-if-changed=resources/source2viewer/Source2Viewer-CLI");
-    let _ = copy_to_output("resources/source2viewer", &std::env::var("PROFILE").unwrap());
+    let _ = copy_to_output(
+        "resources/source2viewer",
+        &std::env::var("PROFILE").unwrap(),
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,11 @@
 {
   description = "deadlocked dev shell for Nix users";
-  
+
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     systems.url = "github:nix-systems/default-linux";
   };
-  
+
   outputs = inputs @ {
     self,
     nixpkgs,
@@ -24,12 +24,12 @@
     packages = eachSystem (system: {
       source2viewer = nixpkgs.legacyPackages.${system}.callPackage ./nix/source2viewer.nix {};
     });
-    
+
     # Development shell
     devShells = eachSystem (system: {
       default = (pkgsFor system).callPackage ./nix/shell.nix {};
     });
-    
+
     # Code formatter
     formatter.x86_64-linux = inputs.nixpkgs.legacyPackages.x86_64-linux.alejandra;
   };

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,6 +1,4 @@
-{ pkgs }:
-
-let
+{pkgs}: let
   # Graphics and X11 libraries
   baseLibs = with pkgs; [
     libx11
@@ -12,30 +10,30 @@ let
 
   source2viewer = pkgs.callPackage ./source2viewer.nix {};
 in
-pkgs.mkShell {
-  name = "deadlocked-dev-shell";
-  
-  nativeBuildInputs = with pkgs;
-    [
-      # Rust toolchain
-      cargo
-      rustc
-      scdoc
-      # Runtime dependencies
-      wayland
-      source2viewer
-      nodejs_24
-      # Development tools
-      cargo-audit
-      cargo-deny
-      pkg-config
-      clippy
-      rust-analyzer
-      rustfmt
-      strace
-      gdb
-    ]
-    ++ baseLibs;
-    
-  LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath baseLibs;
-}
+  pkgs.mkShell {
+    name = "deadlocked-dev-shell";
+
+    nativeBuildInputs = with pkgs;
+      [
+        # Rust toolchain
+        cargo
+        rustc
+        scdoc
+        # Runtime dependencies
+        wayland
+        source2viewer
+        nodejs_24
+        # Development tools
+        cargo-audit
+        cargo-deny
+        pkg-config
+        clippy
+        rust-analyzer
+        rustfmt
+        strace
+        gdb
+      ]
+      ++ baseLibs;
+
+    LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath baseLibs;
+  }

--- a/nix/source2viewer.nix
+++ b/nix/source2viewer.nix
@@ -1,5 +1,8 @@
-{ fetchFromGitHub, buildDotnetModule, dotnetCorePackages }:
-
+{
+  fetchFromGitHub,
+  buildDotnetModule,
+  dotnetCorePackages,
+}:
 # Builds ValveResourceFormat CLI from source
 buildDotnetModule {
   pname = "ValveResourceFormat";

--- a/readme.md
+++ b/readme.md
@@ -116,7 +116,7 @@ cargo run --release
 
 ### Where are my configs saved?
 
-Configs are saved in `$XDG_CONFIG_HOME` if set (usually `$HOME/.config`). Otherwise they're saved alongside the executable.
+Configs are saved in `$XDG_CONFIG_HOME` with fallback to `$HOME/.config`. Otherwise they're saved alongside the executable.
 
 ### How do I configure the radar?
 

--- a/readme.md
+++ b/readme.md
@@ -90,9 +90,14 @@ After reboot:
 ```bash
 git clone --recursive https://github.com/avitran0/deadlocked
 cd deadlocked
-nix flake update
-nix develop
+direnv allow
 cargo run --release
+```
+
+If maps parsing fails, run (it will use Source2Viewer provided by nix direnv instead of one in resources):
+
+```bash
+cargo run --release -- --local-s2v
 ```
 
 Everything is configured in `flake.nix` and `nix/shell.nix`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -346,17 +346,19 @@ impl Default for UnsafeConfig {
 }
 
 pub static CONFIG_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
-    let path = if let Ok(xdg_config) = std::env::var("XDG_CONFIG_HOME") {
-        PathBuf::from(xdg_config).join("deadlocked")
-    } else {
-        std::env::current_exe()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .to_path_buf()
-            .join("configs")
-    };
-    std::fs::create_dir_all(&path).unwrap();
+    let path = std::env::var_os("XDG_CONFIG_HOME")
+        .and_then(|p| if p.is_empty() { None } else { Some(PathBuf::from(p)) })
+        .or_else(|| {
+            std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".config"))
+        })
+        .map(|base| base.join("deadlocked"))
+        .unwrap_or_else(|| {
+            std::env::current_exe()
+                .ok()
+                .and_then(|exe| exe.parent().map(|p| p.join("configs")))
+                .unwrap_or_else(|| PathBuf::from("configs"))
+        });
+    let _ = std::fs::create_dir_all(&path);
     path
 });
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -347,10 +347,14 @@ impl Default for UnsafeConfig {
 
 pub static CONFIG_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
     let path = std::env::var_os("XDG_CONFIG_HOME")
-        .and_then(|p| if p.is_empty() { None } else { Some(PathBuf::from(p)) })
-        .or_else(|| {
-            std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".config"))
+        .and_then(|p| {
+            if p.is_empty() {
+                None
+            } else {
+                Some(PathBuf::from(p))
+            }
         })
+        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")))
         .map(|base| base.join("deadlocked"))
         .unwrap_or_else(|| {
             std::env::current_exe()

--- a/src/cs2/offsets.rs
+++ b/src/cs2/offsets.rs
@@ -135,11 +135,11 @@ pub struct WeaponOffsets {
 
 #[derive(Debug, Default)]
 pub struct PlantedC4Offsets {
-    pub is_ticking: u64,    // bool (m_bBombTicking)
-    pub blow_time: u64,     // f32 (m_flC4Blow)
-    pub being_defused: u64, // bool (m_bBeingDefused)
-    pub is_defused: u64,    // bool (m_bBombDefused)
-    pub has_exploded: u64,  // bool (m_bHasExploded)
+    pub is_ticking: u64,       // bool (m_bBombTicking)
+    pub blow_time: u64,        // f32 (m_flC4Blow)
+    pub being_defused: u64,    // bool (m_bBeingDefused)
+    pub is_defused: u64,       // bool (m_bBombDefused)
+    pub has_exploded: u64,     // bool (m_bHasExploded)
     pub defuse_time_left: u64, // u64 (m_flDefuseCountDown)
 }
 

--- a/src/cs2/planted_c4.rs
+++ b/src/cs2/planted_c4.rs
@@ -54,7 +54,9 @@ impl PlantedC4 {
     }
 
     pub fn time_to_defuse(&self, cs2: &CS2) -> f32 {
-        let defuse_time_left: f32 = cs2.process.read(self.handle + cs2.offsets.planted_c4.defuse_time_left);
+        let defuse_time_left: f32 = cs2
+            .process
+            .read(self.handle + cs2.offsets.planted_c4.defuse_time_left);
         defuse_time_left - cs2.current_time()
     }
 }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1254,17 +1254,17 @@ impl App {
                 self.text(
                     &painter,
                     format!("{:.3}", data.bomb.timer),
-                        pos,
-                        Align2::CENTER_CENTER,
-                        None,
+                    pos,
+                    Align2::CENTER_CENTER,
+                    None,
                 );
                 if data.bomb.being_defused {
                     self.text(
                         &painter,
                         format!("defusing {:.3}", data.bomb.defuse_remain_time),
-                            pos2(pos.x, pos.y + self.config.hud.font_size),
-                              Align2::CENTER_CENTER,
-                              None,
+                        pos2(pos.x, pos.y + self.config.hud.font_size),
+                        Align2::CENTER_CENTER,
+                        None,
                     );
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,9 +61,10 @@ fn main() {
     let bvh_gui = bvh.clone();
 
     let force_reparse = args.iter().any(|arg| arg == "--force-reparse");
+    let use_system_binary = args.iter().any(|arg| arg == "--local-s2v");
     std::thread::spawn(move || {
         crash::install_crash_handler();
-        parse_maps(bvh, force_reparse);
+        parse_maps(bvh, force_reparse, use_system_binary);
     });
 
     let (tx, rx) = unbounded();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -15,7 +15,11 @@ use crate::{
     crash,
 };
 
-pub fn parse_maps(bvh: Arc<Mutex<HashMap<String, Bvh>>>, mut force_reparse: bool, use_system_binary: bool) {
+pub fn parse_maps(
+    bvh: Arc<Mutex<HashMap<String, Bvh>>>,
+    mut force_reparse: bool,
+    use_system_binary: bool,
+) {
     crash::info();
     let source2viewer = exe_path().join("source2viewer/Source2Viewer-CLI");
 
@@ -90,13 +94,11 @@ pub fn parse_maps(bvh: Arc<Mutex<HashMap<String, Bvh>>>, mut force_reparse: bool
             continue;
         }
 
-        let mut s2v_cmd = Command::new(
-            if use_system_binary {
-                std::ffi::OsStr::new("Source2Viewer-CLI")
-            } else {
-                source2viewer.as_os_str()
-            }
-        );
+        let mut s2v_cmd = Command::new(if use_system_binary {
+            std::ffi::OsStr::new("Source2Viewer-CLI")
+        } else {
+            source2viewer.as_os_str()
+        });
         s2v_cmd.args([
             "-i",
             path.to_str().unwrap(),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -15,7 +15,7 @@ use crate::{
     crash,
 };
 
-pub fn parse_maps(bvh: Arc<Mutex<HashMap<String, Bvh>>>, mut force_reparse: bool) {
+pub fn parse_maps(bvh: Arc<Mutex<HashMap<String, Bvh>>>, mut force_reparse: bool, use_system_binary: bool) {
     crash::info();
     let source2viewer = exe_path().join("source2viewer/Source2Viewer-CLI");
 
@@ -90,7 +90,13 @@ pub fn parse_maps(bvh: Arc<Mutex<HashMap<String, Bvh>>>, mut force_reparse: bool
             continue;
         }
 
-        let mut s2v_cmd = Command::new(source2viewer.as_os_str());
+        let mut s2v_cmd = Command::new(
+            if use_system_binary {
+                std::ffi::OsStr::new("Source2Viewer-CLI")
+            } else {
+                source2viewer.as_os_str()
+            }
+        );
         s2v_cmd.args([
             "-i",
             path.to_str().unwrap(),


### PR DESCRIPTION
What's done:
* Fallback to `HOME` if `XDG_CONFIG_HOME` is not set.
* Flag `--local-s2v` to use system binary for `Source2Viewer-CLI`. Sometimes on nix if fails to use binary from resources, so ...
* fmt 