### PR TITLE
Add configurable friendly targeting for ESP and Aimbot

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -77,6 +77,7 @@ impl WeaponConfig {
 pub struct AimbotConfig {
     pub enable_override: bool,
     pub enabled: bool,
+    pub target_friendlies: bool,
     pub start_bullet: i32,
     pub visibility_check: bool,
     pub flash_check: bool,
@@ -91,6 +92,7 @@ impl Default for AimbotConfig {
         Self {
             enable_override: false,
             enabled: true,
+            target_friendlies: false,
             start_bullet: 2,
             visibility_check: true,
             flash_check: true,
@@ -218,6 +220,7 @@ pub enum BoxMode {
 pub struct PlayerConfig {
     pub enabled: bool,
     pub esp_hotkey: KeyCode,
+    pub show_friendlies: bool,
     pub draw_box: DrawMode,
     pub box_mode: BoxMode,
     pub box_visible_color: Color32,
@@ -238,6 +241,7 @@ impl Default for PlayerConfig {
         Self {
             enabled: true,
             esp_hotkey: KeyCode::KeyX,
+            show_friendlies: false,
             draw_box: DrawMode::Color,
             box_mode: BoxMode::Gap,
             box_visible_color: Color32::WHITE,

--- a/src/cs2/mod.rs
+++ b/src/cs2/mod.rs
@@ -242,6 +242,7 @@ impl Game for CS2 {
         data.weapon = local_player.weapon(self);
         data.in_game = true;
         data.is_ffa = self.is_ffa();
+        data.is_custom_mode = self.is_custom_game_mode();
         data.map_name = self.current_map();
         data.triggerbot_active = if self.triggerbot_config(config).mode == TriggerbotMode::Toggle {
             self.trigger.active
@@ -538,6 +539,11 @@ impl CS2 {
 
     fn is_ffa(&self) -> bool {
         self.process.read::<u8>(self.offsets.convar.ffa + 0x50) == 1
+    }
+
+    fn is_custom_game_mode(&self) -> bool {
+        let map = self.current_map();
+        map.starts_with("workshop/") || map.starts_with("custom/") || !map.starts_with("de_") && !map.starts_with("cs_")
     }
 
     // misc

--- a/src/cs2/mod.rs
+++ b/src/cs2/mod.rs
@@ -215,7 +215,6 @@ impl Game for CS2 {
             rotation: local_player.rotation(self),
         };
         data.local_player = local_player_data.clone();
-        data.friendlies.push(local_player_data);
 
         data.entities = self
             .entities

--- a/src/cs2/target.rs
+++ b/src/cs2/target.rs
@@ -59,6 +59,7 @@ impl CS2 {
         let aimbot_config = self.aimbot_config(config);
         let targeting_mode = &aimbot_config.targeting_mode;
         let max_fov = aimbot_config.fov;
+        let is_custom_mode = self.is_custom_game_mode();
 
         let mut best_fov = 360.0;
         let mut best_distance = f32::MAX;
@@ -76,7 +77,7 @@ impl CS2 {
         let target_friendlies = aimbot_config.target_friendlies;
 
         for player in &self.players {
-            if !ffa && !target_friendlies && team == player.team(self) {
+            if !ffa && !(target_friendlies && is_custom_mode) && team == player.team(self) {
                 continue;
             }
 

--- a/src/cs2/target.rs
+++ b/src/cs2/target.rs
@@ -73,8 +73,10 @@ impl CS2 {
             self.target.reset();
         }
 
+        let target_friendlies = aimbot_config.target_friendlies;
+
         for player in &self.players {
-            if !ffa && team == player.team(self) {
+            if !ffa && !target_friendlies && team == player.team(self) {
                 continue;
             }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -9,6 +9,7 @@ use crate::cs2::{bones::Bones, entity::EntityInfo, weapon::Weapon};
 pub struct Data {
     pub in_game: bool,
     pub is_ffa: bool,
+    pub is_custom_mode: bool,
     pub weapon: Weapon,
     pub players: Vec<PlayerData>,
     pub friendlies: Vec<PlayerData>,

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -220,6 +220,13 @@ impl App {
                 self.send_config();
             }
 
+            if ui
+                .checkbox(&mut self.weapon_config().aimbot.target_friendlies, "Target Friendlies")
+                .changed()
+            {
+                self.send_config();
+            }
+
             ui.horizontal(|ui| {
                 if ui
                     .add(
@@ -572,6 +579,13 @@ impl App {
                         }
                     }
                 });
+
+            if ui
+                .checkbox(&mut self.config.player.show_friendlies, "Show Friendlies")
+                .changed()
+            {
+                self.send_config();
+            }
 
             egui::ComboBox::new("draw_box", "Box")
                 .selected_text(format!("{:?}", self.config.player.draw_box))
@@ -1235,6 +1249,13 @@ impl App {
             for player in &data.players {
                 self.player_box(&painter, player, data);
                 self.skeleton(&painter, player, data);
+            }
+
+            if self.config.player.show_friendlies {
+                for player in &data.friendlies {
+                    self.player_box(&painter, player, data);
+                    self.skeleton(&painter, player, data);
+                }
             }
         }
 

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -220,11 +220,14 @@ impl App {
                 self.send_config();
             }
 
-            if ui
-                .checkbox(&mut self.weapon_config().aimbot.target_friendlies, "Target Friendlies")
-                .changed()
-            {
-                self.send_config();
+            if self.data.lock().unwrap().is_custom_mode {
+                if ui
+                    .checkbox(&mut self.weapon_config().aimbot.target_friendlies, "Target Friendlies")
+                    .on_hover_text("Only active in custom game modes (workshop/custom maps)")
+                    .changed()
+                {
+                    self.send_config();
+                }
             }
 
             ui.horizontal(|ui| {
@@ -580,11 +583,14 @@ impl App {
                     }
                 });
 
-            if ui
-                .checkbox(&mut self.config.player.show_friendlies, "Show Friendlies")
-                .changed()
-            {
-                self.send_config();
+            if self.data.lock().unwrap().is_custom_mode {
+                if ui
+                    .checkbox(&mut self.config.player.show_friendlies, "Show Friendlies")
+                    .on_hover_text("Only active in custom game modes (workshop/custom maps)")
+                    .changed()
+                {
+                    self.send_config();
+                }
             }
 
             egui::ComboBox::new("draw_box", "Box")
@@ -1251,7 +1257,7 @@ impl App {
                 self.skeleton(&painter, player, data);
             }
 
-            if self.config.player.show_friendlies {
+            if self.config.player.show_friendlies && data.is_custom_mode {
                 for player in &data.friendlies {
                     self.player_box(&painter, player, data);
                     self.skeleton(&painter, player, data);

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -220,14 +220,12 @@ impl App {
                 self.send_config();
             }
 
-            if self.data.lock().unwrap().is_custom_mode {
-                if ui
-                    .checkbox(&mut self.weapon_config().aimbot.target_friendlies, "Target Friendlies")
-                    .on_hover_text("Only active in custom game modes (workshop/custom maps)")
-                    .changed()
-                {
-                    self.send_config();
-                }
+            if ui
+                .checkbox(&mut self.weapon_config().aimbot.target_friendlies, "Target Friendlies")
+                .on_hover_text("Only active in custom game modes (workshop/custom maps)")
+                .changed()
+            {
+                self.send_config();
             }
 
             ui.horizontal(|ui| {
@@ -583,14 +581,12 @@ impl App {
                     }
                 });
 
-            if self.data.lock().unwrap().is_custom_mode {
-                if ui
-                    .checkbox(&mut self.config.player.show_friendlies, "Show Friendlies")
-                    .on_hover_text("Only active in custom game modes (workshop/custom maps)")
-                    .changed()
-                {
-                    self.send_config();
-                }
+            if ui
+                .checkbox(&mut self.config.player.show_friendlies, "Show Friendlies")
+                .on_hover_text("Only active in custom game modes (workshop/custom maps)")
+                .changed()
+            {
+                self.send_config();
             }
 
             egui::ComboBox::new("draw_box", "Box")


### PR DESCRIPTION
@avitran0 
Adds two checkboxes to allow targeting/rendering friendlies in normal team-based matches.

Changes
ESP: New "Show Friendlies" checkbox in Player settings to render teammate ESP (excludes local player)
Aimbot: New "Target Friendlies" checkbox in Aimbot settings to include teammates as targets
Both features are disabled by default and respect existing FFA mode behavior.

Tested in both FFA and normal game modes.