### PR TITLE
add aimbot toggle mode

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -77,6 +77,7 @@ impl WeaponConfig {
 pub struct AimbotConfig {
     pub enable_override: bool,
     pub enabled: bool,
+    pub mode: AimbotMode,
     pub target_friendlies: bool,
     pub distance_adjusted_fov: bool,
     pub start_bullet: i32,
@@ -93,6 +94,7 @@ impl Default for AimbotConfig {
         Self {
             enable_override: false,
             enabled: true,
+            mode: AimbotMode::Hold,
             target_friendlies: false,
             distance_adjusted_fov: true,
             start_bullet: 0,
@@ -130,6 +132,12 @@ impl Default for RcsConfig {
             smooth: 0.3,
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, EnumIter)]
+pub enum AimbotMode {
+    Hold,
+    Toggle,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, EnumIter)]
@@ -179,7 +187,7 @@ impl Default for TriggerbotConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct AimConfig {
-    pub hotkey: KeyCode,
+    pub aimbot_hotkey: KeyCode,
     pub triggerbot_hotkey: KeyCode,
     pub global: WeaponConfig,
     pub weapons: HashMap<Weapon, WeaponConfig>,
@@ -196,7 +204,7 @@ impl Default for AimConfig {
         }
 
         Self {
-            hotkey: KeyCode::Mouse5,
+            aimbot_hotkey: KeyCode::Mouse5,
             triggerbot_hotkey: KeyCode::Mouse4,
             global: WeaponConfig::enabled(true),
             weapons,

--- a/src/cs2/mod.rs
+++ b/src/cs2/mod.rs
@@ -9,7 +9,7 @@ use glam::{IVec2, Mat4, Vec2, Vec3};
 
 use crate::{
     bvh::Bvh,
-    config::{AimbotConfig, Config, RcsConfig, TriggerbotConfig, TriggerbotMode},
+    config::{AimbotConfig, AimbotMode, Config, RcsConfig, TriggerbotConfig, TriggerbotMode},
     constants::cs2::{self, TEAM_CT, TEAM_T, class},
     cs2::{
         bones::Bones,
@@ -61,6 +61,7 @@ pub struct CS2 {
     wallhack: EspToggle,
     weapon: Weapon,
     planted_c4: Option<PlantedC4>,
+    aimbot_active: bool,
 }
 
 impl Game for CS2 {
@@ -126,7 +127,19 @@ impl Game for CS2 {
 
         self.find_target(config);
 
-        if self.is_button_down(&config.aim.hotkey) {
+        let aimbot_config = self.aimbot_config(config);
+        let hotkey_pressed = self.is_button_down(&config.aim.aimbot_hotkey);
+
+        if aimbot_config.mode == AimbotMode::Toggle && hotkey_pressed {
+            self.aimbot_active = !self.aimbot_active;
+        }
+
+        let should_aim = match aimbot_config.mode {
+            AimbotMode::Toggle => self.aimbot_active,
+            AimbotMode::Hold => hotkey_pressed,
+        };
+
+        if should_aim {
             self.aimbot(config, mouse);
         }
     }
@@ -240,6 +253,11 @@ impl Game for CS2 {
         data.is_ffa = self.is_ffa();
         data.is_custom_mode = self.is_custom_game_mode();
         data.map_name = self.current_map();
+        data.aimbot_active = if self.aimbot_config(config).mode == AimbotMode::Toggle {
+            self.aimbot_active
+        } else {
+            false
+        };
         data.triggerbot_active = if self.triggerbot_config(config).mode == TriggerbotMode::Toggle {
             self.trigger.active
         } else {
@@ -287,6 +305,7 @@ impl CS2 {
             wallhack: EspToggle::default(),
             weapon: Weapon::default(),
             planted_c4: None,
+            aimbot_active: false,
         }
     }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -24,6 +24,7 @@ pub struct Data {
     pub view_angles: Vec2,
     pub window_position: Vec2,
     pub window_size: Vec2,
+    pub aimbot_active: bool,
     pub triggerbot_active: bool,
     pub wallhack_active: bool,
     pub spectators: Vec<(u64, u64)>,

--- a/src/ui/gui.rs
+++ b/src/ui/gui.rs
@@ -5,7 +5,7 @@ use strum::IntoEnumIterator;
 use crate::{
     config::{
         CONFIG_PATH, Config, TargetingMode, TriggerbotMode, VERSION, WeaponConfig,
-        available_configs, delete_config, parse_config, write_config,
+        available_configs, delete_config, parse_config, write_config, AimbotMode
     },
     constants::cs2::GRENADES,
     cs2::{bones::Bones, entity::weapon::Weapon},
@@ -159,12 +159,28 @@ impl App {
     fn aimbot_left(&mut self, ui: &mut Ui) {
         collapsing_open(ui, "Aimbot", |ui| {
             egui::ComboBox::new("aimbot_hotkey", "Hotkey")
-                .selected_text(format!("{:?}", self.config.aim.hotkey))
+                .selected_text(format!("{:?}", self.config.aim.aimbot_hotkey))
                 .show_ui(ui, |ui| {
                     for key_code in KeyCode::iter() {
                         let text = format!("{:?}", &key_code);
                         if ui
-                            .selectable_value(&mut self.config.aim.hotkey, key_code, text)
+                            .selectable_value(&mut self.config.aim.aimbot_hotkey, key_code, text)
+                            .clicked()
+                        {
+                            self.send_config();
+                        }
+                    }
+                })
+                .response
+                .on_hover_text("This key needs to be held for the aimbot to activate");
+
+            egui::ComboBox::new("aimbot_mode", "Mode")
+                .selected_text(format!("{:?}", self.weapon_config().aimbot.mode))
+                .show_ui(ui, |ui| {
+                    for mode in AimbotMode::iter() {
+                        let text = format!("{:?}", &mode);
+                        if ui
+                            .selectable_value(&mut self.weapon_config().aimbot.mode, mode, text)
                             .clicked()
                         {
                             self.send_config();

--- a/src/ui/overlay.rs
+++ b/src/ui/overlay.rs
@@ -191,6 +191,19 @@ impl App {
             );
         }
 
+        if data.aimbot_active {
+            self.text(
+                &painter,
+                "aimbot active",
+                pos2(
+                    data.window_size.x / 2.0 + 8.0,
+                    data.window_size.y / 2.0 + 24.0,
+                ),
+                Align2::LEFT_TOP,
+                None,
+            );
+        }
+
         if self.config.hud.spectators {
             let mut spectators_watching_me = Vec::new();
             for (spectator_name, target_id) in &data.spectator_names {
@@ -761,7 +774,6 @@ impl App {
         }
         let text_center = center - up * CROSS_SIZE;
         if let Some(text_center) = world_to_screen(&text_center, data) {
-            let mut offset = 0.0;
             self.text(
                 painter,
                 &grenade.name,
@@ -772,17 +784,16 @@ impl App {
             self.text(
                 painter,
                 format!("{}", grenade.weapon,),
-                text_center + egui::vec2(0.0, offset),
+                text_center + egui::vec2(0.0, self.config.hud.font_size),
                 Align2::CENTER_TOP,
                 None,
             );
-            offset+=self.config.hud.font_size;
             let text = match (
                 grenade.modifiers.duck,
                 grenade.modifiers.jump,
                 grenade.modifiers.run,
             ) {
-                (false, false, false) => "",
+                (false, false, false) => return,
                 (true, false, false) => "Duck",
                 (true, true, false) => "Duck/Jump",
                 (true, true, true) => "Duck/Jump/Run",
@@ -791,25 +802,14 @@ impl App {
                 (false, true, true) => "Jump/Run",
                 (false, false, true) => "Run",
             };
-            if text != "" {
-                self.text(
-                    painter,
-                    text,
-                    text_center + egui::vec2(0.0, offset),
-                    Align2::CENTER_TOP,
-                    None,
-                );
-                offset+=self.config.hud.font_size;
-            }
-            if grenade.description != "" {
-                self.text(
-                    painter,
-                    &grenade.description,
-                    text_center + egui::vec2(0.0, offset),
-                    Align2::CENTER_TOP,
-                    None,
-                );
-            }
+
+            self.text(
+                painter,
+                text,
+                text_center + egui::vec2(0.0, self.config.hud.font_size * 2.0),
+                Align2::CENTER_TOP,
+                None,
+            );
         }
     }
 


### PR DESCRIPTION
This is my first time programming in rust, so I heavily relied on AI to make this work. I mentioned in https://github.com/avitran0/deadlocked/issues/164 that I'd love to have a feature for the aimbot to have a toggle and a hold mode, the same as the triggerbot has. So I implemented that (and hopefully didn't destroy something else).

If you don't like my implementation that's totally fine, as I said, it's my first time programming in rust. You can also take this as an inspiration to build it properly :)