### PR TITLE
Add Sound ESP

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -238,6 +238,12 @@ pub struct PlayerConfig {
     pub player_name: bool,
     pub weapon_icon: bool,
     pub tags: bool,
+    pub sound_esp_enabled: bool,
+    pub sound_esp_show_friendlies: bool,
+    pub sound_esp_color: Color32,
+    pub sound_esp_footstep_radius: f32,
+    pub sound_esp_gunshot_radius: f32,
+    pub sound_esp_weapon_radius: f32,
 }
 
 impl Default for PlayerConfig {
@@ -259,6 +265,12 @@ impl Default for PlayerConfig {
             player_name: true,
             weapon_icon: true,
             tags: true,
+            sound_esp_enabled: true,
+            sound_esp_show_friendlies: false,
+            sound_esp_color: Color32::WHITE,
+            sound_esp_footstep_radius: 1000.0,   // For footsteps and quiet sounds
+            sound_esp_gunshot_radius: 2500.0,    // For gunshots and explosions
+            sound_esp_weapon_radius: 1500.0,     // For weapon switching, reloading, etc.
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -238,12 +238,7 @@ pub struct PlayerConfig {
     pub player_name: bool,
     pub weapon_icon: bool,
     pub tags: bool,
-    pub sound_esp_enabled: bool,
-    pub sound_esp_show_friendlies: bool,
-    pub sound_esp_color: Color32,
-    pub sound_esp_footstep_radius: f32,
-    pub sound_esp_gunshot_radius: f32,
-    pub sound_esp_weapon_radius: f32,
+    pub sound: SoundConfig,
 }
 
 impl Default for PlayerConfig {
@@ -265,12 +260,29 @@ impl Default for PlayerConfig {
             player_name: true,
             weapon_icon: true,
             tags: true,
-            sound_esp_enabled: true,
-            sound_esp_show_friendlies: false,
-            sound_esp_color: Color32::WHITE,
-            sound_esp_footstep_radius: 1000.0,   // For footsteps and quiet sounds
-            sound_esp_gunshot_radius: 2500.0,    // For gunshots and explosions
-            sound_esp_weapon_radius: 1500.0,     // For weapon switching, reloading, etc.
+            sound: SoundConfig::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SoundConfig {
+    pub enabled: bool,
+    pub color: Color32,
+    pub footstep_radius: f32,
+    pub gunshot_radius: f32,
+    pub weapon_radius: f32,
+}
+
+impl Default for SoundConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            color: Color32::WHITE,
+            footstep_radius: crate::constants::cs2::SOUND_ESP_FOOTSTEP_RADIUS_DEFAULT,
+            gunshot_radius: crate::constants::cs2::SOUND_ESP_GUNSHOT_RADIUS_DEFAULT,
+            weapon_radius: crate::constants::cs2::SOUND_ESP_WEAPON_RADIUS_DEFAULT,
         }
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -19,6 +19,10 @@ pub mod cs2 {
     pub const WEAPON_UNKNOWN: &str = "unknown";
     pub const DEFAULT_FOV: u32 = 90;
 
+    pub const SOUND_ESP_FOOTSTEP_RADIUS_DEFAULT: f32 = 1000.0;
+    pub const SOUND_ESP_GUNSHOT_RADIUS_DEFAULT: f32 = 2500.0;
+    pub const SOUND_ESP_WEAPON_RADIUS_DEFAULT: f32 = 1500.0;
+
     pub const GRENADES: &[Weapon] = &[
         Weapon::Decoy,
         Weapon::Flashbang,

--- a/src/cs2/entity/player.rs
+++ b/src/cs2/entity/player.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
-use std::sync::{Mutex, OnceLock};
 use super::weapon::Weapon;
 
-#[derive(Default)]
-struct SoundPlayerState {
+#[derive(Debug, Default)]
+pub struct SoundPlayerState {
     was_in_air: bool,
     last_weapon: Option<Weapon>,
     last_weapon_switch_time: f32,
@@ -452,14 +451,10 @@ impl Player {
         cs2.process.read(self.pawn + cs2.offsets.pawn.velocity)
     }
     
-    fn player_states() -> &'static Mutex<HashMap<u64, SoundPlayerState>> {
-        static PLAYER_STATES: OnceLock<Mutex<HashMap<u64, SoundPlayerState>>> = OnceLock::new();
-        PLAYER_STATES.get_or_init(|| Mutex::new(HashMap::new()))
-    }
-
     fn is_in_air(&self, cs2: &CS2) -> bool {
-        let velocity = self.velocity(cs2);
-        velocity.z.abs() > 1.0
+        let flags = cs2.process.read::<i32>(self.pawn + cs2.offsets.pawn.flags);
+        // FL_ONGROUND = (1 << 0)
+        (flags & 1) == 0
     }
     
     pub fn is_making_sound(&self, cs2: &CS2) -> Option<crate::data::SoundType> {
@@ -483,7 +478,7 @@ impl Player {
             .as_secs_f32();
         
         // get or initialize player state
-        let mut states = Self::player_states().lock().unwrap();
+        let mut states = cs2.player_states.lock().unwrap();
         let state = states.entry(self.pawn).or_default();
         
         // check for weapon switch
@@ -501,34 +496,14 @@ impl Player {
         // check for scoping (only for snipers)
         let is_scoped = self.is_scoped(cs2);
         
-        // check for reloading
-        // change in the future to use actual reload times
-        let is_reloading = match current_weapon {
-            Weapon::Awp | Weapon::Ssg08 => {
-                // sniper rifles have longer reload times
-                current_time - state.last_weapon_switch_time < 3.7
-            }
-            Weapon::Ak47 | Weapon::M4A4 | Weapon::M4A1 | Weapon::Aug | Weapon::Sg556 => {
-                // rifles
-                current_time - state.last_weapon_switch_time < 2.5
-            }
-            Weapon::P90 | Weapon::Bizon | Weapon::Mp7 | Weapon::Mp9 | Weapon::Ump45 => {
-                // SMGs
-                current_time - state.last_weapon_switch_time < 2.2
-            }
-            Weapon::Nova | Weapon::Xm1014 | Weapon::Sawedoff | Weapon::Mag7 => {
-                // shotguns
-                current_time - state.last_weapon_switch_time < 3.0
-            }
-            _ => false,
-        };
+        // check for reloading removed - half-baked feature
         
         let weapon_switch_sound = current_time - state.last_weapon_switch_time < 0.5;
         if is_walking || is_standing {
             return None;
         }
 
-        if is_reloading || weapon_switch_sound || is_scoped && matches!(current_weapon, Weapon::Awp | Weapon::Ssg08) {
+        if weapon_switch_sound || is_scoped && matches!(current_weapon, Weapon::Awp | Weapon::Ssg08) {
             Some(crate::data::SoundType::Weapon)
         } else if speed > 150.0 || is_jumping || just_landed {
             Some(crate::data::SoundType::Footstep)

--- a/src/cs2/entity/player.rs
+++ b/src/cs2/entity/player.rs
@@ -1,13 +1,6 @@
 use std::collections::HashMap;
 use super::weapon::Weapon;
 
-#[derive(Debug, Default)]
-pub struct SoundPlayerState {
-    was_in_air: bool,
-    last_weapon: Option<Weapon>,
-    last_weapon_switch_time: f32,
-}
-
 use glam::{Vec2, Vec3};
 
 use crate::{
@@ -465,47 +458,22 @@ impl Player {
         
         let velocity = self.velocity(cs2);
         let speed = (velocity.x * velocity.x + velocity.y * velocity.y).sqrt();
+        let current_weapon = self.weapon(cs2);
         
         let is_jumping = velocity.z > 100.0 && self.is_in_air(cs2);
         let is_walking = speed > 100.0 && speed <= 150.0;
         let is_standing = speed < 10.0;
         
-        // get current weapon and time
-        let current_weapon = self.weapon(cs2);
-        let current_time = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs_f32();
-        
-        // get or initialize player state
-        let mut states = cs2.player_states.lock().unwrap();
-        let state = states.entry(self.pawn).or_default();
-        
-        // check for weapon switch
-        let weapon_switched = state.last_weapon != Some(current_weapon.clone());
-        if weapon_switched {
-            state.last_weapon = Some(current_weapon.clone());
-            state.last_weapon_switch_time = current_time;
-        }
-        
-        // dheck for landing (was in air last frame, now on ground)
-        let is_now_in_air = self.is_in_air(cs2);
-        let just_landed = state.was_in_air && !is_now_in_air;
-        state.was_in_air = is_now_in_air;
-        
         // check for scoping (only for snipers)
         let is_scoped = self.is_scoped(cs2);
         
-        // check for reloading removed - half-baked feature
-        
-        let weapon_switch_sound = current_time - state.last_weapon_switch_time < 0.5;
         if is_walking || is_standing {
             return None;
         }
 
-        if weapon_switch_sound || is_scoped && matches!(current_weapon, Weapon::Awp | Weapon::Ssg08) {
+        if is_scoped && matches!(current_weapon, Weapon::Awp | Weapon::Ssg08) {
             Some(crate::data::SoundType::Weapon)
-        } else if speed > 150.0 || is_jumping || just_landed {
+        } else if speed > 150.0 || is_jumping || velocity.z < -200.0 {
             Some(crate::data::SoundType::Footstep)
         } else {
             None

--- a/src/cs2/entity/player.rs
+++ b/src/cs2/entity/player.rs
@@ -7,7 +7,6 @@ struct SoundPlayerState {
     was_in_air: bool,
     last_weapon: Option<Weapon>,
     last_weapon_switch_time: f32,
-    last_reload_time: f32,
 }
 
 use glam::{Vec2, Vec3};

--- a/src/cs2/entity/player.rs
+++ b/src/cs2/entity/player.rs
@@ -1,10 +1,20 @@
 use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use super::weapon::Weapon;
+
+#[derive(Default)]
+struct SoundPlayerState {
+    was_in_air: bool,
+    last_weapon: Option<Weapon>,
+    last_weapon_switch_time: f32,
+    last_reload_time: f32,
+}
 
 use glam::{Vec2, Vec3};
 
 use crate::{
     constants::cs2,
-    cs2::{bones::Bones, entity::weapon::Weapon},
+    cs2::bones::Bones,
 };
 
 use super::{CS2, weapon_class::WeaponClass};
@@ -441,6 +451,91 @@ impl Player {
     #[allow(unused)]
     pub fn velocity(&self, cs2: &CS2) -> Vec3 {
         cs2.process.read(self.pawn + cs2.offsets.pawn.velocity)
+    }
+    
+    fn player_states() -> &'static Mutex<HashMap<u64, SoundPlayerState>> {
+        static PLAYER_STATES: OnceLock<Mutex<HashMap<u64, SoundPlayerState>>> = OnceLock::new();
+        PLAYER_STATES.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    fn is_in_air(&self, cs2: &CS2) -> bool {
+        let velocity = self.velocity(cs2);
+        velocity.z.abs() > 1.0
+    }
+    
+    pub fn is_making_sound(&self, cs2: &CS2) -> Option<crate::data::SoundType> {
+        let shots_fired = self.shots_fired(cs2);
+        if shots_fired > 0 {
+            return Some(crate::data::SoundType::Gunshot);
+        }
+        
+        let velocity = self.velocity(cs2);
+        let speed = (velocity.x * velocity.x + velocity.y * velocity.y).sqrt();
+        
+        let is_jumping = velocity.z > 100.0 && self.is_in_air(cs2);
+        let is_walking = speed > 100.0 && speed <= 150.0;
+        let is_standing = speed < 10.0;
+        
+        // get current weapon and time
+        let current_weapon = self.weapon(cs2);
+        let current_time = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs_f32();
+        
+        // get or initialize player state
+        let mut states = Self::player_states().lock().unwrap();
+        let state = states.entry(self.pawn).or_default();
+        
+        // check for weapon switch
+        let weapon_switched = state.last_weapon != Some(current_weapon.clone());
+        if weapon_switched {
+            state.last_weapon = Some(current_weapon.clone());
+            state.last_weapon_switch_time = current_time;
+        }
+        
+        // dheck for landing (was in air last frame, now on ground)
+        let is_now_in_air = self.is_in_air(cs2);
+        let just_landed = state.was_in_air && !is_now_in_air;
+        state.was_in_air = is_now_in_air;
+        
+        // check for scoping (only for snipers)
+        let is_scoped = self.is_scoped(cs2);
+        
+        // check for reloading
+        // change in the future to use actual reload times
+        let is_reloading = match current_weapon {
+            Weapon::Awp | Weapon::Ssg08 => {
+                // sniper rifles have longer reload times
+                current_time - state.last_weapon_switch_time < 3.7
+            }
+            Weapon::Ak47 | Weapon::M4A4 | Weapon::M4A1 | Weapon::Aug | Weapon::Sg556 => {
+                // rifles
+                current_time - state.last_weapon_switch_time < 2.5
+            }
+            Weapon::P90 | Weapon::Bizon | Weapon::Mp7 | Weapon::Mp9 | Weapon::Ump45 => {
+                // SMGs
+                current_time - state.last_weapon_switch_time < 2.2
+            }
+            Weapon::Nova | Weapon::Xm1014 | Weapon::Sawedoff | Weapon::Mag7 => {
+                // shotguns
+                current_time - state.last_weapon_switch_time < 3.0
+            }
+            _ => false,
+        };
+        
+        let weapon_switch_sound = current_time - state.last_weapon_switch_time < 0.5;
+        if is_walking || is_standing {
+            return None;
+        }
+
+        if is_reloading || weapon_switch_sound || is_scoped && matches!(current_weapon, Weapon::Awp | Weapon::Ssg08) {
+            Some(crate::data::SoundType::Weapon)
+        } else if speed > 150.0 || is_jumping || just_landed {
+            Some(crate::data::SoundType::Footstep)
+        } else {
+            None
+        }
     }
 
     pub fn no_flash(&self, cs2: &CS2, flash_alpha: f32) {

--- a/src/cs2/mod.rs
+++ b/src/cs2/mod.rs
@@ -16,7 +16,7 @@ use crate::{
         bones::Bones,
         entity::{
             Entity, EntityInfo, GrenadeInfo, inferno::Inferno, molotov::Molotov,
-            planted_c4::PlantedC4, player::Player, smoke::Smoke, weapon::Weapon,
+            planted_c4::PlantedC4, player::{Player, SoundPlayerState}, smoke::Smoke, weapon::Weapon,
         },
         esp_toggle::EspToggle,
         offsets::Offsets,
@@ -61,6 +61,7 @@ pub struct CS2 {
     wallhack: EspToggle,
     weapon: Weapon,
     planted_c4: Option<PlantedC4>,
+    player_states: Mutex<HashMap<u64, SoundPlayerState>>,
 }
 
 impl Game for CS2 {
@@ -169,13 +170,11 @@ impl Game for CS2 {
             let _is_making_sound = player.is_making_sound(self);
             let health = player.health(self);
 
-            let sound_type = player.is_making_sound(self);
+            let sound = player.is_making_sound(self);
             let player_data = PlayerData {
-                sound_timestamp: if sound_type.is_some() { Some(0.0) } else { None },
-                sound_type,
+                sound,
                 steam_id: player.steam_id(self),
                 health,
-                last_health: health,
                 armor: player.armor(self),
                 position: player.position(self),
                 head: player.bone_position(self, Bones::Head.u64()),
@@ -197,13 +196,11 @@ impl Game for CS2 {
         }
 
         let local_health = local_player.health(self);
-        let local_sound_type = local_player.is_making_sound(self);
-        let local_player_data = PlayerData {
-            sound_timestamp: if local_sound_type.is_some() { Some(0.0) } else { None },
-            sound_type: local_sound_type,
+        let local_sound = local_player.is_making_sound(self);
+        data.local_player = PlayerData {
+            sound: local_sound,
             steam_id: local_player.steam_id(self),
             health: local_health,
-            last_health: local_health,
             armor: local_player.armor(self),
             position: local_player.position(self),
             head: local_player.bone_position(self, Bones::Head.u64()),
@@ -217,7 +214,6 @@ impl Game for CS2 {
             color: local_player.color(self),
             rotation: local_player.rotation(self),
         };
-        data.local_player = local_player_data.clone();
 
         data.entities = self
             .entities
@@ -300,6 +296,7 @@ impl CS2 {
             wallhack: EspToggle::default(),
             weapon: Weapon::default(),
             planted_c4: None,
+            player_states: Mutex::new(HashMap::new()),
         }
     }
 
@@ -472,6 +469,7 @@ impl CS2 {
         offsets.pawn.eye_offset = client.get("C_BaseModelEntity", "m_vecViewOffset")?;
         offsets.pawn.eye_angles = client.get("C_CSPlayerPawn", "m_angEyeAngles")?;
         offsets.pawn.velocity = client.get("C_BaseEntity", "m_vecAbsVelocity")?;
+        offsets.pawn.flags = client.get("C_BaseEntity", "m_fFlags")?;
         offsets.pawn.aim_punch_cache = client.get("C_CSPlayerPawn", "m_aimPunchCache")?;
         offsets.pawn.shots_fired = client.get("C_CSPlayerPawn", "m_iShotsFired")?;
         offsets.pawn.view_angles = client.get("C_BasePlayerPawn", "v_angle")?;

--- a/src/cs2/mod.rs
+++ b/src/cs2/mod.rs
@@ -16,7 +16,7 @@ use crate::{
         bones::Bones,
         entity::{
             Entity, EntityInfo, GrenadeInfo, inferno::Inferno, molotov::Molotov,
-            planted_c4::PlantedC4, player::{Player, SoundPlayerState}, smoke::Smoke, weapon::Weapon,
+            planted_c4::PlantedC4, player::Player, smoke::Smoke, weapon::Weapon,
         },
         esp_toggle::EspToggle,
         offsets::Offsets,
@@ -61,7 +61,6 @@ pub struct CS2 {
     wallhack: EspToggle,
     weapon: Weapon,
     planted_c4: Option<PlantedC4>,
-    player_states: Mutex<HashMap<u64, SoundPlayerState>>,
 }
 
 impl Game for CS2 {
@@ -167,9 +166,7 @@ impl Game for CS2 {
             return;
         }
         for player in &self.players {
-            let _is_making_sound = player.is_making_sound(self);
             let health = player.health(self);
-
             let sound = player.is_making_sound(self);
             let player_data = PlayerData {
                 sound,
@@ -195,12 +192,10 @@ impl Game for CS2 {
             }
         }
 
-        let local_health = local_player.health(self);
-        let local_sound = local_player.is_making_sound(self);
         data.local_player = PlayerData {
-            sound: local_sound,
+            sound: local_player.is_making_sound(self),
             steam_id: local_player.steam_id(self),
-            health: local_health,
+            health: local_player.health(self),
             armor: local_player.armor(self),
             position: local_player.position(self),
             head: local_player.bone_position(self, Bones::Head.u64()),
@@ -296,7 +291,6 @@ impl CS2 {
             wallhack: EspToggle::default(),
             weapon: Weapon::default(),
             planted_c4: None,
-            player_states: Mutex::new(HashMap::new()),
         }
     }
 

--- a/src/cs2/mod.rs
+++ b/src/cs2/mod.rs
@@ -166,9 +166,16 @@ impl Game for CS2 {
             return;
         }
         for player in &self.players {
+            let _is_making_sound = player.is_making_sound(self);
+            let health = player.health(self);
+
+            let sound_type = player.is_making_sound(self);
             let player_data = PlayerData {
+                sound_timestamp: if sound_type.is_some() { Some(0.0) } else { None },
+                sound_type,
                 steam_id: player.steam_id(self),
-                health: player.health(self),
+                health,
+                last_health: health,
                 armor: player.armor(self),
                 position: player.position(self),
                 head: player.bone_position(self, Bones::Head.u64()),
@@ -189,9 +196,14 @@ impl Game for CS2 {
             }
         }
 
+        let local_health = local_player.health(self);
+        let local_sound_type = local_player.is_making_sound(self);
         let local_player_data = PlayerData {
+            sound_timestamp: if local_sound_type.is_some() { Some(0.0) } else { None },
+            sound_type: local_sound_type,
             steam_id: local_player.steam_id(self),
-            health: local_player.health(self),
+            health: local_health,
+            last_health: local_health,
             armor: local_player.armor(self),
             position: local_player.position(self),
             head: local_player.bone_position(self, Bones::Head.u64()),

--- a/src/cs2/offsets.rs
+++ b/src/cs2/offsets.rs
@@ -54,6 +54,7 @@ pub struct PawnOffsets {
     pub eye_offset: u64,          // Vec3 (m_vecViewOffset)
     pub eye_angles: u64,          // Vec3 (m_angEyeAngles)
     pub velocity: u64,            // Vec3 (m_vecAbsVelocity)
+    pub flags: u64,               // i32 (m_fFlags)
     pub aim_punch_cache: u64,     // Vector<Vec3> (m_aimPunchCache)
     pub shots_fired: u64,         // i32 (m_iShotsFired)
     pub view_angles: u64,         // Vec2 (v_angle)

--- a/src/data.rs
+++ b/src/data.rs
@@ -42,8 +42,6 @@ pub struct Data {
 pub struct PlayerData {
     pub steam_id: u64,
     pub health: i32,
-    #[serde(skip_serializing)]
-    pub last_health: i32,
     pub armor: i32,
     pub position: Vec3,
     pub head: Vec3,
@@ -56,8 +54,7 @@ pub struct PlayerData {
     pub visible: bool,
     pub color: i32,
     pub rotation: f32,
-    pub sound_timestamp: Option<f32>,
-    pub sound_type: Option<SoundType>,
+    pub sound: Option<SoundType>,
 }
 
 #[derive(Debug, Default, Serialize)]

--- a/src/data.rs
+++ b/src/data.rs
@@ -8,6 +8,13 @@ use crate::cs2::{
     entity::{EntityInfo, weapon::Weapon},
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub enum SoundType {
+    Footstep,
+    Gunshot,
+    Weapon,
+}
+
 #[derive(Debug, Default, Serialize)]
 pub struct Data {
     pub in_game: bool,
@@ -35,6 +42,8 @@ pub struct Data {
 pub struct PlayerData {
     pub steam_id: u64,
     pub health: i32,
+    #[serde(skip_serializing)]
+    pub last_health: i32,
     pub armor: i32,
     pub position: Vec3,
     pub head: Vec3,
@@ -47,6 +56,8 @@ pub struct PlayerData {
     pub visible: bool,
     pub color: i32,
     pub rotation: f32,
+    pub sound_timestamp: Option<f32>,
+    pub sound_type: Option<SoundType>,
 }
 
 #[derive(Debug, Default, Serialize)]

--- a/src/ui/gui/player.rs
+++ b/src/ui/gui/player.rs
@@ -191,7 +191,6 @@ impl App {
                     }
                 });
                 
-                // Gunshot radius slider
                 ui.horizontal(|ui| {
                     ui.label("Gunshot Range:");
                     
@@ -213,7 +212,6 @@ impl App {
                     }
                 });
                 
-                // Weapon sound radius
                 ui.horizontal(|ui| {
                     ui.label("Weapon Range:");
                     

--- a/src/ui/gui/player.rs
+++ b/src/ui/gui/player.rs
@@ -41,8 +41,8 @@ impl App {
                         self.config.player.skeleton_color = color;
                         self.send_config();
                     }
-                    if let Some(color) = self.color_picker(ui, &self.config.player.sound_esp_color, "Sound ESP") {
-                        self.config.player.sound_esp_color = color;
+                    if let Some(color) = self.color_picker(ui, &self.config.player.sound.color, "Sound ESP") {
+                        self.config.player.sound.color = color;
                         self.send_config();
                     }
 
@@ -152,37 +152,26 @@ impl App {
         });
         collapsing_open(ui, "Sound ESP", |ui| {
                 if ui
-                    .checkbox(&mut self.config.player.sound_esp_enabled, "Enabled")
+                    .checkbox(&mut self.config.player.sound.enabled, "Enabled")
                     .on_hover_text("Show a circle under players when they make sound")
                     .changed()
                 {
                     self.send_config();
                 }
                 
-            if self.config.player.sound_esp_enabled {
-                if ui
-                    .checkbox(
-                        &mut self.config.player.sound_esp_show_friendlies,
-                        "Show Friendlies",
-                    )
-                    .changed()
-                {
-                    self.send_config();
-                }
-                                
+            if self.config.player.sound.enabled {
                 ui.horizontal(|ui| {
-                    ui.label("Footstep Range:");
+                    ui.label("Footstep Range");
                     
                     let response = ui.add(
-                        egui::DragValue::new(&mut self.config.player.sound_esp_footstep_radius)
+                        egui::DragValue::new(&mut self.config.player.sound.footstep_radius)
                             .speed(10.0)
                             .range(100.0..=3000.0)
                             .suffix(" units")
                     );
                     
-                    let default_footstep = 1000.0;
-                    if ui.button("↺").on_hover_text("Reset to default (1000)").clicked() {
-                        self.config.player.sound_esp_footstep_radius = default_footstep;
+                    if ui.button("↺").on_hover_text("Reset").clicked() {
+                        self.config.player.sound.footstep_radius = crate::constants::cs2::SOUND_ESP_FOOTSTEP_RADIUS_DEFAULT;
                         self.send_config();
                     }
                     
@@ -192,18 +181,17 @@ impl App {
                 });
                 
                 ui.horizontal(|ui| {
-                    ui.label("Gunshot Range:");
+                    ui.label("Gunshot Range");
                     
                     let response = ui.add(
-                        egui::DragValue::new(&mut self.config.player.sound_esp_gunshot_radius)
+                        egui::DragValue::new(&mut self.config.player.sound.gunshot_radius)
                             .speed(10.0)
                             .range(100.0..=5000.0)
                             .suffix(" units")
                     );
                     
-                    let default_gunshot = 2500.0;
-                    if ui.button("↺").on_hover_text("Reset to default (2500)").clicked() {
-                        self.config.player.sound_esp_gunshot_radius = default_gunshot;
+                    if ui.button("↺").on_hover_text("Reset").clicked() {
+                        self.config.player.sound.gunshot_radius = crate::constants::cs2::SOUND_ESP_GUNSHOT_RADIUS_DEFAULT;
                         self.send_config();
                     }
                     
@@ -213,18 +201,17 @@ impl App {
                 });
                 
                 ui.horizontal(|ui| {
-                    ui.label("Weapon Range:");
+                    ui.label("Weapon Range");
                     
                     let response = ui.add(
-                        egui::DragValue::new(&mut self.config.player.sound_esp_weapon_radius)
+                        egui::DragValue::new(&mut self.config.player.sound.weapon_radius)
                             .speed(10.0)
                             .range(100.0..=3000.0)
                             .suffix(" units")
                     );
                     
-                    let default_weapon = 1500.0;
-                    if ui.button("↺").on_hover_text("Reset to default (1500)").clicked() {
-                        self.config.player.sound_esp_weapon_radius = default_weapon;
+                    if ui.button("↺").on_hover_text("Reset").clicked() {
+                        self.config.player.sound.weapon_radius = crate::constants::cs2::SOUND_ESP_WEAPON_RADIUS_DEFAULT;
                         self.send_config();
                     }
                     

--- a/src/ui/gui/player.rs
+++ b/src/ui/gui/player.rs
@@ -176,7 +176,7 @@ impl App {
                     let response = ui.add(
                         egui::DragValue::new(&mut self.config.player.sound_esp_footstep_radius)
                             .speed(10.0)
-                            .clamp_range(100.0..=3000.0)
+                            .range(100.0..=3000.0)
                             .suffix(" units")
                     );
                     
@@ -197,7 +197,7 @@ impl App {
                     let response = ui.add(
                         egui::DragValue::new(&mut self.config.player.sound_esp_gunshot_radius)
                             .speed(10.0)
-                            .clamp_range(100.0..=5000.0)
+                            .range(100.0..=5000.0)
                             .suffix(" units")
                     );
                     
@@ -218,7 +218,7 @@ impl App {
                     let response = ui.add(
                         egui::DragValue::new(&mut self.config.player.sound_esp_weapon_radius)
                             .speed(10.0)
-                            .clamp_range(100.0..=3000.0)
+                            .range(100.0..=3000.0)
                             .suffix(" units")
                     );
                     

--- a/src/ui/gui/player.rs
+++ b/src/ui/gui/player.rs
@@ -41,6 +41,10 @@ impl App {
                         self.config.player.skeleton_color = color;
                         self.send_config();
                     }
+                    if let Some(color) = self.color_picker(ui, &self.config.player.sound_esp_color, "Sound ESP") {
+                        self.config.player.sound_esp_color = color;
+                        self.send_config();
+                    }
 
                     ui.horizontal(|ui| {
                         if ui
@@ -144,6 +148,92 @@ impl App {
                 .changed()
             {
                 self.send_config();
+            }
+        });
+        collapsing_open(ui, "Sound ESP", |ui| {
+                if ui
+                    .checkbox(&mut self.config.player.sound_esp_enabled, "Enabled")
+                    .on_hover_text("Show a circle under players when they make sound")
+                    .changed()
+                {
+                    self.send_config();
+                }
+                
+            if self.config.player.sound_esp_enabled {
+                if ui
+                    .checkbox(
+                        &mut self.config.player.sound_esp_show_friendlies,
+                        "Show Friendlies",
+                    )
+                    .changed()
+                {
+                    self.send_config();
+                }
+                                
+                ui.horizontal(|ui| {
+                    ui.label("Footstep Range:");
+                    
+                    let response = ui.add(
+                        egui::DragValue::new(&mut self.config.player.sound_esp_footstep_radius)
+                            .speed(10.0)
+                            .clamp_range(100.0..=3000.0)
+                            .suffix(" units")
+                    );
+                    
+                    let default_footstep = 1000.0;
+                    if ui.button("↺").on_hover_text("Reset to default (1000)").clicked() {
+                        self.config.player.sound_esp_footstep_radius = default_footstep;
+                        self.send_config();
+                    }
+                    
+                    if response.changed() {
+                        self.send_config();
+                    }
+                });
+                
+                // Gunshot radius slider
+                ui.horizontal(|ui| {
+                    ui.label("Gunshot Range:");
+                    
+                    let response = ui.add(
+                        egui::DragValue::new(&mut self.config.player.sound_esp_gunshot_radius)
+                            .speed(10.0)
+                            .clamp_range(100.0..=5000.0)
+                            .suffix(" units")
+                    );
+                    
+                    let default_gunshot = 2500.0;
+                    if ui.button("↺").on_hover_text("Reset to default (2500)").clicked() {
+                        self.config.player.sound_esp_gunshot_radius = default_gunshot;
+                        self.send_config();
+                    }
+                    
+                    if response.changed() {
+                        self.send_config();
+                    }
+                });
+                
+                // Weapon sound radius
+                ui.horizontal(|ui| {
+                    ui.label("Weapon Range:");
+                    
+                    let response = ui.add(
+                        egui::DragValue::new(&mut self.config.player.sound_esp_weapon_radius)
+                            .speed(10.0)
+                            .clamp_range(100.0..=3000.0)
+                            .suffix(" units")
+                    );
+                    
+                    let default_weapon = 1500.0;
+                    if ui.button("↺").on_hover_text("Reset to default (1500)").clicked() {
+                        self.config.player.sound_esp_weapon_radius = default_weapon;
+                        self.send_config();
+                    }
+                    
+                    if response.changed() {
+                        self.send_config();
+                    }
+                });
             }
         });
     }

--- a/src/ui/overlay.rs
+++ b/src/ui/overlay.rs
@@ -14,6 +14,7 @@ use crate::{
         },
     },
     data::{Data, PlayerData},
+    data::SoundType,
     math::world_to_screen,
     ui::{app::App, color::Colors, grenades::Grenade, trail::Trail},
 };
@@ -25,34 +26,21 @@ impl App {
         player: &crate::data::PlayerData,
         data: &crate::data::Data,
     ) {
-        if !self.config.player.sound_esp_enabled
-            || (player.sound_timestamp.is_none() && player.last_health <= player.health)
-        {
+        if !self.config.player.sound.enabled || player.sound.is_none() {
             return;
         }
 
         let distance = (player.position - data.local_player.position).length();
-        let sound_radius = match player.sound_type {
-            Some(crate::data::SoundType::Gunshot) => self.config.player.sound_esp_gunshot_radius,
-            Some(crate::data::SoundType::Weapon) => self.config.player.sound_esp_weapon_radius,
-            Some(crate::data::SoundType::Footstep) | None => self.config.player.sound_esp_footstep_radius,
+        let sound_radius = match player.sound {
+            Some(SoundType::Gunshot) => self.config.player.sound.gunshot_radius,
+            Some(SoundType::Weapon) => self.config.player.sound.weapon_radius,
+            Some(SoundType::Footstep) | None => self.config.player.sound.footstep_radius,
         };
 
         if distance > sound_radius {
             return;
         }
 
-        // check if the sound is recent (within 200ms)
-        let _is_recent = if let Some(timestamp) = player.sound_timestamp {
-            let current_time = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs_f32();
-            current_time - timestamp < 0.2
-        } else {
-            false
-        };
-        
         let feet_pos = player.position - Vec3::new(0.0, 0.0, 10.0);
         
         if let Some(screen_pos) = world_to_screen(&feet_pos, data) {
@@ -64,7 +52,7 @@ impl App {
             
             let normalized_distance = (distance / sound_radius).min(1.0);
             let alpha = 1.0 - normalized_distance * 0.8;
-            let color = self.config.player.sound_esp_color.gamma_multiply(alpha as f32);
+            let color = self.config.player.sound.color.gamma_multiply(alpha as f32);
             
             let line_width = (2.0 * (1.0 + 1.0 / (distance * 0.01 + 1.0))).min(4.0);
             
@@ -125,10 +113,8 @@ impl App {
             }
         }
 
-        if self.config.player.show_friendlies && data.is_custom_mode && self.config.player.sound_esp_show_friendlies {
+        if self.config.player.show_friendlies && data.is_custom_mode {
             for player in &data.friendlies {
-                self.draw_sound_esp(&painter, player, data);
-                
                 if data.wallhack_active {
                     self.player_box(&painter, player, data);
                     self.skeleton(&painter, player, data);

--- a/src/ui/overlay.rs
+++ b/src/ui/overlay.rs
@@ -52,7 +52,7 @@ impl App {
             
             let normalized_distance = (distance / sound_radius).min(1.0);
             let alpha = 1.0 - normalized_distance * 0.8;
-            let color = self.config.player.sound.color.gamma_multiply(alpha as f32);
+            let color = self.config.player.sound.color.gamma_multiply(alpha);
             
             let line_width = (2.0 * (1.0 + 1.0 / (distance * 0.01 + 1.0))).min(4.0);
             

--- a/src/ui/overlay.rs
+++ b/src/ui/overlay.rs
@@ -19,6 +19,62 @@ use crate::{
 };
 
 impl App {
+    fn draw_sound_esp(
+        &self,
+        painter: &egui::Painter,
+        player: &crate::data::PlayerData,
+        data: &crate::data::Data,
+    ) {
+        if !self.config.player.sound_esp_enabled
+            || (player.sound_timestamp.is_none() && player.last_health <= player.health)
+        {
+            return;
+        }
+
+        let distance = (player.position - data.local_player.position).length();
+        let sound_radius = match player.sound_type {
+            Some(crate::data::SoundType::Gunshot) => self.config.player.sound_esp_gunshot_radius,
+            Some(crate::data::SoundType::Weapon) => self.config.player.sound_esp_weapon_radius,
+            Some(crate::data::SoundType::Footstep) | None => self.config.player.sound_esp_footstep_radius,
+        };
+
+        if distance > sound_radius {
+            return;
+        }
+
+        // check if the sound is recent (within 200ms)
+        let _is_recent = if let Some(timestamp) = player.sound_timestamp {
+            let current_time = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs_f32();
+            current_time - timestamp < 0.2
+        } else {
+            false
+        };
+        
+        let feet_pos = player.position - Vec3::new(0.0, 0.0, 10.0);
+        
+        if let Some(screen_pos) = world_to_screen(&feet_pos, data) {
+            let max_size = 40.0;
+            let min_size = 5.0;
+            
+            let distance_ratio = 1.0 - (distance / sound_radius).min(1.0);
+            let visual_radius = min_size + (max_size - min_size) * distance_ratio;
+            
+            let normalized_distance = (distance / sound_radius).min(1.0);
+            let alpha = 1.0 - normalized_distance * 0.8;
+            let color = self.config.player.sound_esp_color.gamma_multiply(alpha as f32);
+            
+            let line_width = (2.0 * (1.0 + 1.0 / (distance * 0.01 + 1.0))).min(4.0);
+            
+            painter.circle_stroke(
+                screen_pos,
+                visual_radius,
+                egui::Stroke::new(line_width, color),
+            );
+        }
+    }
     fn aimbot_config(&self, weapon: &Weapon) -> &AimbotConfig {
         if let Some(weapon_config) = self.config.aim.weapons.get(weapon)
             && weapon_config.aimbot.enable_override
@@ -60,14 +116,20 @@ impl App {
             );
         }
 
-        if data.wallhack_active {
-            for player in &data.players {
+        for player in &data.players {
+            self.draw_sound_esp(&painter, player, data);
+            
+            if data.wallhack_active {
                 self.player_box(&painter, player, data);
                 self.skeleton(&painter, player, data);
             }
+        }
 
-            if self.config.player.show_friendlies && data.is_custom_mode {
-                for player in &data.friendlies {
+        if self.config.player.show_friendlies && data.is_custom_mode && self.config.player.sound_esp_show_friendlies {
+            for player in &data.friendlies {
+                self.draw_sound_esp(&painter, player, data);
+                
+                if data.wallhack_active {
                     self.player_box(&painter, player, data);
                     self.skeleton(&painter, player, data);
                 }


### PR DESCRIPTION

<img width="1425" height="826" alt="Screenshot_20251123_161541" src="https://github.com/user-attachments/assets/094dddcc-fe4e-44de-9c99-acfcd4183a6b" />
<img width="2073" height="1349" alt="Screenshot_20251123_161607" src="https://github.com/user-attachments/assets/ea0126bc-3fdc-42b3-8181-06464eb117b8" />

Adds a new Sound ESP feature that displays visual cues when players make sounds. This makes audio information easier to notice and interpret during gameplay aka legit hacking

## Sound detection
   - Added SoundType enum (Footstep, Gunshot, Weapon) to categorize different sound types
   - Implemented sound detection in Player::is_making_sound() to identify:
     - Gunshots (from weapon fire)
     - Weapon sounds (reloading, switching, scoping)
     - Footsteps and movement sounds

## Visual feedback

- Visual indicators (circles) under players when they make sounds
- Implemented distance-based alpha fading for better visibility
- Circle vary in size by sound type
- Color picker for the indicator
- Added UI controls in the Sound ESP menu:
     - Toggle for enabling/disabling the feature
     - "Show Friendlies" option to include teammates
     - Color picker for the sound ESP indicator
   - Added configurable ranges for different sound types:
     - Footstep Range (default: 1000 units)
     - Gunshot Range (default: 2500 units)
     - Weapon Sound Range (default: 1500 units)
   - Added reset buttons to quickly restore default values
- Reset buttons to restore default ranges.
- Added sound type tracking in PlayerData
- Implemented sound duration tracking with timestamps

Optimized to only render relevant sounds.