### PR TITLE
update fixes

### DIFF
--- a/src/cs2/find_offsets.rs
+++ b/src/cs2/find_offsets.rs
@@ -62,7 +62,7 @@ impl CS2 {
 
         let Some(view_matrix) = self
             .process
-            .scan("4C 8D 0D ? ? ? ? 4C 89 E6 4C 8D 05", offsets.library.client)
+            .scan("C6 83 ? ? 00 00 01 4C 8D 05", offsets.library.client)
         else {
             log::warn!("could not find view matrix offset");
             return None;

--- a/src/cs2/mod.rs
+++ b/src/cs2/mod.rs
@@ -360,11 +360,11 @@ impl CS2 {
 
     // convars
     fn get_sensitivity(&self) -> f32 {
-        self.process.read(self.offsets.convar.sensitivity + 0x50)
+        self.process.read(self.offsets.convar.sensitivity + 0x58)
     }
 
     fn is_ffa(&self) -> bool {
-        self.process.read::<u8>(self.offsets.convar.ffa + 0x50) == 1
+        self.process.read::<u8>(self.offsets.convar.ffa + 0x58) == 1
     }
 
     fn is_custom_game_mode(&self) -> bool {


### PR DESCRIPTION
Not comprehensive, at least these things are still not fixed:
- something in `get_entities_in_bucket` is broken. Can be sort of fixed by using `char* m_designerName` (`identity_offset + 0x20`), which has names that are different from schema class names because of course it does. Some useful names I've noticed:
	- `c_cs_player_for_precache` - `C_CSPlayerPawn`
	- `c_cs_observer_for_precache` - `C_CSObserverPawn`
	- `weapon_*` - all weapons
  A few things may not have usable designer names, e.g. I haven't seen anything resembling `CMapInfo`.
- `aim_punch_cache` is no longer in schema (see https://github.com/a2x/cs2-dumper/pull/510)