### PR TITLE
setup adds hyprland windowrule

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -18,3 +18,17 @@ echo "added user $CURRENT_USER to group $UINPUT_GROUP"
 sudo udevadm control --reload-rules
 sudo udevadm trigger
 echo "reloaded udev rules"
+
+if [ "$XDG_CURRENT_DESKTOP" = "Hyprland" ]; then
+    echo "detected Hyprland as window manager"
+    
+    RULE="windowrule = no_blur 1, match:title ^(deadlocked_overlay)$"
+    CONF_FILE="$HOME/.config/hypr/hyprland.conf"
+
+    if grep -Fxq "$RULE" "$CONF_FILE"; then
+        echo "deadlocked_overlay windowrule has already been added, skipping"
+    else
+        echo "$RULE" >> "$CONF_FILE"
+        echo "added windowrule to Hyprland"
+    fi
+fi


### PR DESCRIPTION
Now if you run setup.sh the first time and you are using Hyprland as your window manager, it will add `windowrule = no_blur 1, match:title ^(deadlocked_overlay)$` to your hyprland.conf located in ~/.config/hypr/hyprland.conf