### PR TITLE
‎ 

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -79,6 +79,7 @@ pub struct AimbotConfig {
     pub distance_adjusted_fov: bool,
     pub start_bullet: i32,
     pub visibility_check: bool,
+    pub smoke_wall_check: bool,
     pub flash_check: bool,
     pub fov: f32,
     pub smooth: f32,
@@ -91,14 +92,15 @@ impl Default for AimbotConfig {
         Self {
             enable_override: false,
             enabled: true,
-            mode: KeyMode::Hold,
+            mode: KeyMode::Shoot,
             target_friendlies: false,
             distance_adjusted_fov: true,
-            start_bullet: 0,
+            start_bullet: 1,
             visibility_check: true,
+            smoke_wall_check: true,
             flash_check: true,
-            fov: 2.5,
-            smooth: 5.0,
+            fov: 1.8,
+            smooth: 8.5,
             bones: vec![
                 Bones::Head,
                 Bones::Neck,
@@ -135,6 +137,7 @@ impl Default for RcsConfig {
 pub enum KeyMode {
     Hold,
     Toggle,
+    Shoot,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, EnumIter)]
@@ -152,9 +155,14 @@ pub struct TriggerbotConfig {
     pub shot_duration: u64,
     pub mode: KeyMode,
     pub flash_check: bool,
+    pub smoke_wall_check: bool,
     pub scope_check: bool,
     pub velocity_check: bool,
     pub velocity_threshold: f32,
+    pub aim_assist: bool,
+    pub aim_fov: f32,
+    pub aim_smooth: f32,
+    pub fire_fov: f32,
     pub head_only: bool,
 }
 
@@ -162,14 +170,19 @@ impl Default for TriggerbotConfig {
     fn default() -> Self {
         Self {
             enable_override: false,
-            enabled: false,
-            delay: 100..=200,
-            shot_duration: 200,
-            mode: KeyMode::Hold,
+            enabled: true,
+            delay: 85..=145,
+            shot_duration: 16,
+            mode: KeyMode::Shoot,
             flash_check: true,
+            smoke_wall_check: true,
             scope_check: true,
-            velocity_check: true,
-            velocity_threshold: 100.0,
+            velocity_check: false,
+            velocity_threshold: 220.0,
+            aim_assist: true,
+            aim_fov: 1.8,
+            aim_smooth: 4.0,
+            fire_fov: 0.22,
             head_only: false,
         }
     }
@@ -192,8 +205,8 @@ impl Default for AimConfig {
         }
 
         Self {
-            aimbot_hotkey: KeyCode::Mouse5,
-            triggerbot_hotkey: KeyCode::Mouse4,
+            aimbot_hotkey: KeyCode::MouseLeft,
+            triggerbot_hotkey: KeyCode::MouseLeft,
             global: WeaponConfig::enabled(true),
             weapons,
         }
@@ -305,6 +318,8 @@ pub struct HudConfig {
     pub line_width: f32,
     pub font_size: f32,
     pub icon_size: f32,
+    pub overlay_refresh_rate: u64,
+    pub data_refresh_rate: u64,
     pub debug: bool,
 }
 
@@ -328,6 +343,8 @@ impl Default for HudConfig {
             line_width: 2.0,
             font_size: 16.0,
             icon_size: 20.0,
+            overlay_refresh_rate: 120,
+            data_refresh_rate: 90,
             debug: false,
         }
     }
@@ -356,6 +373,11 @@ pub struct UnsafeConfig {
     pub max_flash_alpha: f32,
     pub fov_changer: bool,
     pub desired_fov: u32,
+    pub silent_aim: bool,
+    pub telemetry_enabled: bool,
+    pub auto_counter_strafe: bool,
+    pub counter_strafe_tap_ms: u64,
+    pub counter_strafe_speed_threshold: f32,
     pub no_smoke: bool,
     pub change_smoke_color: bool,
     pub smoke_color: Color32,
@@ -368,6 +390,11 @@ impl Default for UnsafeConfig {
             max_flash_alpha: 127.0,
             fov_changer: false,
             desired_fov: 90,
+            silent_aim: false,
+            telemetry_enabled: true,
+            auto_counter_strafe: true,
+            counter_strafe_tap_ms: 18,
+            counter_strafe_speed_threshold: 22.0,
             no_smoke: false,
             change_smoke_color: false,
             smoke_color: Color32::RED,

--- a/src/cs2/entity/player.rs
+++ b/src/cs2/entity/player.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use glam::{Vec2, Vec3, vec2};
 
-use crate::{constants::cs2, cs2::bones::Bones, data::SoundType};
+use crate::{constants::cs2, cs2::bones::Bones, data::SoundType, math::vec2_clamp};
 
 use super::{CS2, weapon_class::WeaponClass};
 
@@ -128,7 +128,7 @@ impl Player {
 
     pub fn name(&self, cs2: &CS2) -> String {
         cs2.process
-            .read_string_uncached(self.controller + cs2.offsets.controller.name)
+            .read_string(self.controller + cs2.offsets.controller.name)
     }
 
     /// returns a pawn-only player
@@ -344,6 +344,12 @@ impl Player {
 
     pub fn view_angles(&self, cs2: &CS2) -> Vec2 {
         cs2.process.read(self.pawn + cs2.offsets.pawn.view_angles)
+    }
+
+    pub fn set_view_angles(&self, cs2: &CS2, mut angles: Vec2) {
+        vec2_clamp(&mut angles);
+        cs2.process
+            .write(self.pawn + cs2.offsets.pawn.view_angles, angles);
     }
 
     pub fn aim_punch(&self, cs2: &CS2) -> Vec2 {

--- a/src/cs2/features/aimbot.rs
+++ b/src/cs2/features/aimbot.rs
@@ -3,7 +3,7 @@ use utils::log;
 
 use crate::{
     config::{Config, KeyMode},
-    cs2::{CS2, entity::player::Player},
+    cs2::{CS2, entity::player::Player, key_codes::KeyCode},
     math::{angles_to_fov, vec2_clamp},
     os::mouse::Mouse,
 };
@@ -16,6 +16,7 @@ pub struct Aimbot {
 impl CS2 {
     pub fn aimbot(&mut self, config: &Config, mouse: &mut Mouse) {
         let hotkey = config.aim.aimbot_hotkey;
+        let silent_aim = config.misc.silent_aim;
         let config = self.aimbot_config(config);
 
         if !config.enabled {
@@ -38,6 +39,11 @@ impl CS2 {
                     return;
                 }
             }
+            KeyMode::Shoot => {
+                if !self.input.is_key_pressed(KeyCode::MouseLeft) {
+                    return;
+                }
+            }
         }
 
         if self.target.player.is_none() && self.target_grenade.is_none() {
@@ -56,6 +62,13 @@ impl CS2 {
 
         if !grenade && config.visibility_check && !target.unwrap().visible(self, &local_player) {
             return;
+        }
+
+        if !grenade && config.smoke_wall_check {
+            let target_position = target.unwrap().bone_position(self, self.target.bone_index);
+            if !self.is_path_clear(local_player.eye_position(self), target_position) {
+                return;
+            }
         }
 
         let target_angle = {
@@ -117,6 +130,11 @@ impl CS2 {
             aim_angles.y / sensitivity * 50.0,
             -aim_angles.x / sensitivity * 50.0,
         ) / (if grenade { 1.0 } else { config.smooth + 1.0 }).clamp(1.0, 20.0);
+
+        if !grenade && config.mode == KeyMode::Shoot && silent_aim {
+            local_player.set_view_angles(self, target_angle);
+            return;
+        }
 
         log::debug!(
             "aimbot mouse movement: {:.2}/{:.2}",

--- a/src/cs2/features/counter_strafe.rs
+++ b/src/cs2/features/counter_strafe.rs
@@ -1,0 +1,163 @@
+use std::time::{Duration, Instant};
+
+use glam::vec2;
+
+use crate::{
+    config::Config,
+    cs2::{CS2, entity::player::Player, key_codes::KeyCode},
+    os::mouse::{Mouse, MovementKey},
+};
+
+#[derive(Debug, Default)]
+pub struct CounterStrafe {
+    last_tap: Option<Instant>,
+    release_w: Option<Instant>,
+    release_a: Option<Instant>,
+    release_s: Option<Instant>,
+    release_d: Option<Instant>,
+}
+
+impl CS2 {
+    pub fn counter_strafe_tick(&mut self, config: &Config, mouse: &mut Mouse) {
+        self.counter_strafe_release_pending(mouse);
+
+        if !config.misc.auto_counter_strafe || !self.input.is_key_pressed(KeyCode::MouseLeft) {
+            return;
+        }
+        let Some(local_player) = Player::local_player(self) else {
+            return;
+        };
+        self.counter_strafe_on_shot(config, mouse, &local_player);
+    }
+
+    pub(crate) fn counter_strafe_on_shot(
+        &mut self,
+        config: &Config,
+        mouse: &mut Mouse,
+        local_player: &Player,
+    ) {
+        if !config.misc.auto_counter_strafe {
+            return;
+        }
+
+        let now = Instant::now();
+        const MIN_TAP_INTERVAL: Duration = Duration::from_millis(80);
+        if let Some(last_tap) = self.counter_strafe.last_tap
+            && now.duration_since(last_tap) < MIN_TAP_INTERVAL
+        {
+            return;
+        }
+
+        let tap_duration = Duration::from_millis(config.misc.counter_strafe_tap_ms.clamp(5, 60));
+
+        let mut tapped = false;
+
+        let holding_w = self.input.is_key_pressed(KeyCode::W);
+        let holding_a = self.input.is_key_pressed(KeyCode::A);
+        let holding_s = self.input.is_key_pressed(KeyCode::S);
+        let holding_d = self.input.is_key_pressed(KeyCode::D);
+
+        if holding_w || holding_a || holding_s || holding_d {
+            if holding_w {
+                self.counter_strafe_press_for(mouse, MovementKey::S, now, tap_duration);
+                tapped = true;
+            }
+            if holding_s {
+                self.counter_strafe_press_for(mouse, MovementKey::W, now, tap_duration);
+                tapped = true;
+            }
+            if holding_a {
+                self.counter_strafe_press_for(mouse, MovementKey::D, now, tap_duration);
+                tapped = true;
+            }
+            if holding_d {
+                self.counter_strafe_press_for(mouse, MovementKey::A, now, tap_duration);
+                tapped = true;
+            }
+        } else {
+            let velocity = local_player.velocity(self);
+            let velocity_2d = vec2(velocity.x, velocity.y);
+            let speed = velocity_2d.length();
+            if speed < config.misc.counter_strafe_speed_threshold {
+                return;
+            }
+
+            // Convert world velocity into local forward/right speeds based on current yaw.
+            let yaw = local_player.view_angles(self).y.to_radians();
+            let forward = vec2(yaw.cos(), yaw.sin());
+            let right = vec2(-yaw.sin(), yaw.cos());
+            let forward_speed = velocity_2d.dot(forward);
+            let right_speed = velocity_2d.dot(right);
+
+            let threshold = config.misc.counter_strafe_speed_threshold;
+            if right_speed > threshold {
+                self.counter_strafe_press_for(mouse, MovementKey::A, now, tap_duration);
+                self.counter_strafe_press_for(mouse, MovementKey::D, now, tap_duration);
+                tapped = true;
+            } else if right_speed < -threshold {
+                self.counter_strafe_press_for(mouse, MovementKey::D, now, tap_duration);
+                self.counter_strafe_press_for(mouse, MovementKey::A, now, tap_duration);
+                tapped = true;
+            }
+
+            if forward_speed > threshold {
+                self.counter_strafe_press_for(mouse, MovementKey::S, now, tap_duration);
+                self.counter_strafe_press_for(mouse, MovementKey::W, now, tap_duration);
+                tapped = true;
+            } else if forward_speed < -threshold {
+                self.counter_strafe_press_for(mouse, MovementKey::W, now, tap_duration);
+                self.counter_strafe_press_for(mouse, MovementKey::S, now, tap_duration);
+                tapped = true;
+            }
+        }
+
+        if tapped {
+            self.counter_strafe.last_tap = Some(now);
+        }
+    }
+
+    fn counter_strafe_press_for(
+        &mut self,
+        mouse: &mut Mouse,
+        key: MovementKey,
+        now: Instant,
+        duration: Duration,
+    ) {
+        mouse.movement_press(key);
+        let release_at = now + duration;
+        match key {
+            MovementKey::W => self.counter_strafe.release_w = Some(release_at),
+            MovementKey::A => self.counter_strafe.release_a = Some(release_at),
+            MovementKey::S => self.counter_strafe.release_s = Some(release_at),
+            MovementKey::D => self.counter_strafe.release_d = Some(release_at),
+        }
+    }
+
+    fn counter_strafe_release_pending(&mut self, mouse: &mut Mouse) {
+        let now = Instant::now();
+        if let Some(release_at) = self.counter_strafe.release_w
+            && now >= release_at
+        {
+            mouse.movement_release(MovementKey::W);
+            self.counter_strafe.release_w = None;
+        }
+        if let Some(release_at) = self.counter_strafe.release_a
+            && now >= release_at
+        {
+            mouse.movement_release(MovementKey::A);
+            self.counter_strafe.release_a = None;
+        }
+        if let Some(release_at) = self.counter_strafe.release_s
+            && now >= release_at
+        {
+            mouse.movement_release(MovementKey::S);
+            self.counter_strafe.release_s = None;
+        }
+        if let Some(release_at) = self.counter_strafe.release_d
+            && now >= release_at
+        {
+            mouse.movement_release(MovementKey::D);
+            self.counter_strafe.release_d = None;
+        }
+    }
+}

--- a/src/cs2/features/mod.rs
+++ b/src/cs2/features/mod.rs
@@ -1,4 +1,5 @@
 pub mod aimbot;
+pub mod counter_strafe;
 pub mod esp_toggle;
 mod fov_changer;
 mod no_flash;

--- a/src/cs2/features/triggerbot.rs
+++ b/src/cs2/features/triggerbot.rs
@@ -1,6 +1,6 @@
 use std::time::{Duration, Instant};
 
-use glam::Vec2;
+use glam::{Vec2, vec2};
 use rand::rng;
 
 use crate::{
@@ -9,8 +9,9 @@ use crate::{
         CS2,
         bones::Bones,
         entity::{player::Player, weapon_class::WeaponClass},
+        key_codes::KeyCode,
     },
-    math::angles_to_fov,
+    math::{angles_to_fov, vec2_clamp},
     os::mouse::Mouse,
 };
 
@@ -18,19 +19,28 @@ use crate::{
 pub struct Triggerbot {
     shot_start: Option<Instant>,
     shot_end: Option<Instant>,
+    cooldown_end: Option<Instant>,
+    pending_silent_angle: Option<Vec2>,
     pub active: bool,
 }
 
-impl CS2 {
-    pub fn triggerbot(&mut self, config: &Config) {
-        let hotkey = config.aim.triggerbot_hotkey;
-        let config = self.triggerbot_config(config);
+#[derive(Debug, Clone, Copy)]
+struct TriggerCandidate {
+    angle: Vec2,
+    fov: f32,
+    from_crosshair: bool,
+}
 
-        if !config.enabled {
+impl CS2 {
+    pub fn triggerbot(&mut self, config: &Config, mouse: &mut Mouse) {
+        let hotkey = config.aim.triggerbot_hotkey;
+        let trigger_config = self.triggerbot_config(config).clone();
+
+        if !trigger_config.enabled {
             return;
         }
 
-        match config.mode {
+        match trigger_config.mode {
             KeyMode::Hold => {
                 if !self.input.is_key_pressed(hotkey) {
                     return;
@@ -44,6 +54,18 @@ impl CS2 {
                     return;
                 }
             }
+            KeyMode::Shoot => {
+                if !self.input.is_key_pressed(KeyCode::MouseLeft) {
+                    return;
+                }
+            }
+        }
+
+        let now = Instant::now();
+        if let Some(cooldown_end) = self.trigger.cooldown_end
+            && now < cooldown_end
+        {
+            return;
         }
 
         if self.trigger.shot_start.is_some() || self.trigger.shot_end.is_some() {
@@ -54,56 +76,179 @@ impl CS2 {
             return;
         };
 
-        if config.flash_check && local_player.is_flashed(self) {
+        if trigger_config.flash_check && local_player.is_flashed(self) {
             return;
         }
 
-        if config.scope_check
-            && local_player.weapon_class(self) == WeaponClass::Sniper
+        let weapon_class = local_player.weapon_class(self);
+        if trigger_config.scope_check
+            && weapon_class == WeaponClass::Sniper
             && !local_player.is_scoped(self)
         {
             return;
         }
 
-        if config.velocity_check && local_player.velocity(self).length() > config.velocity_threshold
-        {
-            return;
-        }
-
-        let Some(player) = local_player.crosshair_entity(self) else {
-            return;
-        };
-
-        if !self.is_ffa() && player.team(self) == local_player.team(self) {
-            return;
-        }
-
-        if config.head_only {
-            let head = player.bone_position(self, Bones::Head.u64());
-
-            let target_angle = self.angle_to_target(&local_player, &head, &Vec2::ZERO);
-            let view_angles = local_player.view_angles(self);
-            let fov = angles_to_fov(&view_angles, &target_angle);
-
-            let head_radius_fov =
-                3.5 / (local_player.position(self) - player.position(self)).length() * 100.0;
-
-            if fov > head_radius_fov {
+        if trigger_config.velocity_check {
+            let velocity = local_player.velocity(self);
+            let horizontal_speed = vec2(velocity.x, velocity.y).length();
+            if horizontal_speed > trigger_config.velocity_threshold {
                 return;
             }
         }
 
-        let mean = (*config.delay.start() + *config.delay.end()) as f32 / 2.0;
-        let std_dev = (*config.delay.end() - *config.delay.start()) as f32 / 2.0;
+        let eye_position = local_player.eye_position(self);
+        let view_angles = local_player.view_angles(self);
+        let aim_punch = local_player.aim_punch(self) * 2.0;
+        let local_team = local_player.team(self);
+        let bone_list: &[Bones] = if trigger_config.head_only {
+            &[Bones::Head]
+        } else {
+            &[
+                Bones::Head,
+                Bones::Neck,
+                Bones::Spine3,
+                Bones::Spine1,
+                Bones::Hip,
+            ]
+        };
 
-        let normal = rand_distr::Normal::new(mean, std_dev).unwrap();
-        use rand_distr::Distribution as _;
-        let delay = normal.sample(&mut rng()).max(0.0) as u64;
+        let build_candidate =
+            |player: Player, from_crosshair: bool, cs2: &CS2| -> Option<TriggerCandidate> {
+                if !player.is_valid(cs2) {
+                    return None;
+                }
 
-        let now = Instant::now();
-        let delay = Duration::from_millis(delay);
-        self.trigger.shot_start = Some(now + delay);
-        self.trigger.shot_end = Some(now + delay + Duration::from_millis(config.shot_duration));
+                if !cs2.is_ffa() && player.team(cs2) == local_team {
+                    return None;
+                }
+
+                let mut best_fov = f32::MAX;
+                let mut best_angle = Vec2::ZERO;
+                let mut found = false;
+                for bone in bone_list {
+                    let target_bone = player.bone_position(cs2, bone.u64());
+                    if target_bone == glam::Vec3::ZERO {
+                        continue;
+                    }
+                    if trigger_config.smoke_wall_check
+                        && !cs2.is_path_clear(eye_position, target_bone)
+                    {
+                        continue;
+                    }
+
+                    let angle = cs2.angle_to_target(&local_player, &target_bone, &aim_punch);
+                    let fov = angles_to_fov(&view_angles, &angle);
+                    if fov < best_fov {
+                        best_fov = fov;
+                        best_angle = angle;
+                        found = true;
+                    }
+                }
+
+                if !found {
+                    return None;
+                }
+
+                Some(TriggerCandidate {
+                    angle: best_angle,
+                    fov: best_fov,
+                    from_crosshair,
+                })
+            };
+
+        let mut candidate = local_player
+            .crosshair_entity(self)
+            .and_then(|player| build_candidate(player, true, self));
+
+        if candidate.is_none() && trigger_config.aim_assist {
+            let mut best_candidate = None;
+            for player in &self.players {
+                let Some(player_candidate) = build_candidate(*player, false, self) else {
+                    continue;
+                };
+                if player_candidate.fov > trigger_config.aim_fov {
+                    continue;
+                }
+                if best_candidate
+                    .as_ref()
+                    .map(|best: &TriggerCandidate| player_candidate.fov < best.fov)
+                    .unwrap_or(true)
+                {
+                    best_candidate = Some(player_candidate);
+                }
+            }
+            candidate = best_candidate;
+        }
+
+        let Some(candidate) = candidate else {
+            return;
+        };
+
+        if trigger_config.aim_assist && candidate.fov <= trigger_config.aim_fov {
+            let mut aim_delta = view_angles - candidate.angle;
+            if aim_delta.y < -180.0 {
+                aim_delta.y += 360.0;
+            }
+            vec2_clamp(&mut aim_delta);
+
+            let sensitivity = self.get_sensitivity() * local_player.fov_multiplier(self);
+            let smooth = (trigger_config.aim_smooth + 1.0).clamp(1.0, 20.0);
+            let mouse_angles = vec2(
+                aim_delta.y / sensitivity * 50.0,
+                -aim_delta.x / sensitivity * 50.0,
+            ) / smooth;
+
+            if mouse_angles.length_squared() > f32::EPSILON {
+                mouse.move_rel(&mouse_angles);
+            }
+        }
+
+        let should_fire = candidate.from_crosshair
+            || (trigger_config.aim_assist && candidate.fov <= trigger_config.fire_fov);
+        if !should_fire {
+            return;
+        }
+
+        self.counter_strafe_on_shot(config, mouse, &local_player);
+
+        let min_delay = *trigger_config.delay.start();
+        let max_delay = *trigger_config.delay.end();
+        let delay_ms = if min_delay == max_delay {
+            min_delay
+        } else {
+            let mean = (min_delay + max_delay) as f32 / 2.0;
+            let std_dev = ((max_delay - min_delay) as f32 / 2.0).max(1.0);
+            let Ok(normal) = rand_distr::Normal::new(mean, std_dev) else {
+                return;
+            };
+            use rand_distr::Distribution as _;
+            normal
+                .sample(&mut rng())
+                .round()
+                .clamp(min_delay as f32, max_delay as f32) as u64
+        };
+
+        let tap_fire = weapon_class == WeaponClass::Pistol
+            || weapon_class == WeaponClass::Shotgun
+            || weapon_class == WeaponClass::Sniper;
+        let press_duration_ms = if tap_fire {
+            trigger_config.shot_duration.clamp(5, 25)
+        } else {
+            trigger_config.shot_duration.clamp(5, 250)
+        };
+        let cooldown_ms = if tap_fire { 16 } else { 8 };
+
+        let delay = Duration::from_millis(delay_ms);
+        let start = now + delay;
+        self.trigger.shot_start = Some(start);
+        self.trigger.shot_end = Some(start + Duration::from_millis(press_duration_ms));
+        self.trigger.cooldown_end =
+            Some(start + Duration::from_millis(press_duration_ms + cooldown_ms));
+        self.trigger.pending_silent_angle = if config.misc.silent_aim {
+            Some(candidate.angle)
+        } else {
+            None
+        };
     }
 
     pub fn triggerbot_shoot(&mut self, mouse: &mut Mouse) {
@@ -112,6 +257,11 @@ impl CS2 {
         if let Some(shot_time) = self.trigger.shot_start
             && now >= shot_time
         {
+            if let Some(shot_angle) = self.trigger.pending_silent_angle.take()
+                && let Some(local_player) = Player::local_player(self)
+            {
+                local_player.set_view_angles(self, shot_angle);
+            }
             mouse.left_press();
             self.trigger.shot_start = None;
         }
@@ -121,6 +271,12 @@ impl CS2 {
         {
             mouse.left_release();
             self.trigger.shot_end = None;
+        }
+
+        if let Some(cooldown_end) = self.trigger.cooldown_end
+            && now >= cooldown_end
+        {
+            self.trigger.cooldown_end = None;
         }
     }
 }

--- a/src/cs2/mod.rs
+++ b/src/cs2/mod.rs
@@ -1,17 +1,23 @@
-use std::sync::Arc;
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use glam::{IVec2, Mat4, Vec2, Vec3};
 use utils::{log, sync::Mutex};
 
 use crate::{
-    config::{AimbotConfig, Config, KeyMode, RcsConfig, TriggerbotConfig},
+    config::{AimbotConfig, Config, DrawMode, KeyMode, RcsConfig, TriggerbotConfig},
     constants::cs2::{self, TEAM_CT, TEAM_T},
     cs2::{
         bones::Bones,
         entity::{
             Entity, EntityInfo, GrenadeInfo, planted_c4::PlantedC4, player::Player, weapon::Weapon,
         },
-        features::{aimbot::Aimbot, esp_toggle::EspToggle, rcs::Recoil, triggerbot::Triggerbot},
+        features::{
+            aimbot::Aimbot, counter_strafe::CounterStrafe, esp_toggle::EspToggle, rcs::Recoil,
+            triggerbot::Triggerbot,
+        },
         input::Input,
         offsets::Offsets,
         target::Target,
@@ -34,6 +40,9 @@ mod offsets;
 mod schema;
 mod target;
 
+const WORLD_SCAN_INTERVAL: Duration = Duration::from_millis(50);
+const BVH_CHECK_INTERVAL: Duration = Duration::from_secs(1);
+
 #[derive(Debug)]
 pub struct CS2 {
     is_valid: bool,
@@ -48,9 +57,12 @@ pub struct CS2 {
     recoil: Recoil,
     aim: Aimbot,
     trigger: Triggerbot,
+    counter_strafe: CounterStrafe,
     esp: EspToggle,
     weapon: Weapon,
     planted_c4: Option<PlantedC4>,
+    next_world_scan: Instant,
+    next_bvh_check: Instant,
     grenades: Arc<Mutex<GrenadeList>>,
     target_grenade: Option<Grenade>,
 }
@@ -90,9 +102,31 @@ impl Game for CS2 {
 
         self.input.update(&self.process, &self.offsets);
 
-        // self.cache_players();
-        self.cache_entities();
-        self.check_bvh();
+        let now = Instant::now();
+        let requires_strict_occlusion = self.aimbot_config(config).smoke_wall_check
+            || self.triggerbot_config(config).smoke_wall_check;
+        let world_scan_enabled = config.hud.bomb_timer
+            || config.hud.dropped_weapons
+            || config.hud.grenade_trails
+            || config.misc.no_smoke
+            || config.misc.change_smoke_color
+            || requires_strict_occlusion;
+
+        if world_scan_enabled && now >= self.next_world_scan {
+            self.cache_entities();
+            self.next_world_scan = now + WORLD_SCAN_INTERVAL;
+        } else {
+            self.cache_players();
+            if !world_scan_enabled {
+                self.entities.clear();
+                self.planted_c4 = None;
+            }
+        }
+
+        if now >= self.next_bvh_check {
+            self.check_bvh();
+            self.next_bvh_check = now + BVH_CHECK_INTERVAL;
+        }
 
         for entity in &self.entities {
             if let Entity::Smoke(smoke) = entity {
@@ -111,14 +145,12 @@ impl Game for CS2 {
 
         self.esp_toggle(config);
 
+        self.counter_strafe_tick(config, mouse);
         self.rcs(config, mouse);
-        self.triggerbot(config);
-
-        self.triggerbot_shoot(mouse);
-
         self.find_target(config);
-
         self.aimbot(config, mouse);
+        self.triggerbot(config, mouse);
+        self.triggerbot_shoot(mouse);
     }
 
     fn data(&self, config: &Config, data: &mut Data) {
@@ -150,6 +182,17 @@ impl Game for CS2 {
             return;
         }
 
+        let player_esp_enabled = config.player.enabled;
+        let collect_player_names = player_esp_enabled && config.player.player_name;
+        let collect_player_bones = player_esp_enabled
+            && (config.player.draw_skeleton != DrawMode::None || config.player.head_circle);
+        let collect_player_tags = player_esp_enabled && config.player.tags;
+        let collect_player_visibility = player_esp_enabled
+            && (config.player.visible_only
+                || (config.player.sound.enabled && config.player.sound.show_visible)
+                || matches!(config.player.draw_box, DrawMode::Color));
+        let collect_player_sound = player_esp_enabled && config.player.sound.enabled;
+
         for player in &self.players {
             let player_data = PlayerData {
                 steam_id: player.steam_id(self),
@@ -157,16 +200,32 @@ impl Game for CS2 {
                 armor: player.armor(self),
                 position: player.position(self),
                 head: player.bone_position(self, Bones::Head.u64()),
-                name: player.name(self),
+                name: if collect_player_names {
+                    player.name(self)
+                } else {
+                    String::new()
+                },
                 weapon: player.weapon(self),
-                bones: player.all_bones(self),
-                has_defuser: player.has_defuser(self),
-                has_helmet: player.has_helmet(self),
-                has_bomb: player.has_bomb(self),
-                visible: player.visible(self, &local_player),
+                bones: if collect_player_bones {
+                    player.all_bones(self)
+                } else {
+                    Default::default()
+                },
+                has_defuser: collect_player_tags && player.has_defuser(self),
+                has_helmet: collect_player_tags && player.has_helmet(self),
+                has_bomb: collect_player_tags && player.has_bomb(self),
+                visible: if collect_player_visibility {
+                    player.visible(self, &local_player)
+                } else {
+                    true
+                },
                 color: player.color(self),
                 rotation: player.rotation(self),
-                sound: player.is_making_sound(self),
+                sound: if collect_player_sound {
+                    player.is_making_sound(self)
+                } else {
+                    None
+                },
             };
 
             if !self.is_ffa() && player.team(self) == local_team {
@@ -182,12 +241,12 @@ impl Game for CS2 {
             armor: local_player.armor(self),
             position: local_player.position(self),
             head: local_player.bone_position(self, Bones::Head.u64()),
-            name: local_player.name(self),
+            name: String::new(),
             weapon: local_player.weapon(self),
-            bones: local_player.all_bones(self),
-            has_defuser: local_player.has_defuser(self),
-            has_helmet: local_player.has_helmet(self),
-            has_bomb: local_player.has_bomb(self),
+            bones: Default::default(),
+            has_defuser: false,
+            has_helmet: false,
+            has_bomb: false,
             visible: true,
             color: local_player.color(self),
             rotation: local_player.rotation(self),
@@ -264,9 +323,12 @@ impl CS2 {
             recoil: Recoil::default(),
             aim: Aimbot::default(),
             trigger: Triggerbot::default(),
+            counter_strafe: CounterStrafe::default(),
             esp: EspToggle::default(),
             weapon: Weapon::default(),
             planted_c4: None,
+            next_world_scan: Instant::now(),
+            next_bvh_check: Instant::now(),
             grenades,
             target_grenade: None,
         }
@@ -307,6 +369,47 @@ impl CS2 {
         vec2_clamp(&mut angles);
 
         angles
+    }
+
+    pub(crate) fn is_path_clear(&self, start: Vec3, end: Vec3) -> bool {
+        if let Some(bvh) = &self.bvh {
+            if !bvh.has_line_of_sight(start, end) {
+                return false;
+            }
+        } else {
+            // If we cannot validate geometry LOS, fail closed to avoid aiming through walls.
+            return false;
+        }
+
+        !self.segment_hits_smoke(start, end)
+    }
+
+    fn segment_hits_smoke(&self, start: Vec3, end: Vec3) -> bool {
+        const SMOKE_RADIUS: f32 = 145.0;
+        const SMOKE_RADIUS_SQ: f32 = SMOKE_RADIUS * SMOKE_RADIUS;
+
+        let segment = end - start;
+        let segment_len_sq = segment.length_squared();
+
+        for entity in &self.entities {
+            let Entity::Smoke(smoke) = entity else {
+                continue;
+            };
+
+            let center = smoke.info(self).position;
+            let t = if segment_len_sq > f32::EPSILON {
+                ((center - start).dot(segment) / segment_len_sq).clamp(0.0, 1.0)
+            } else {
+                0.0
+            };
+            let closest = start + segment * t;
+
+            if center.distance_squared(closest) <= SMOKE_RADIUS_SQ {
+                return true;
+            }
+        }
+
+        false
     }
 
     fn entity_has_owner(&self, entity: u64) -> bool {

--- a/src/cs2/target.rs
+++ b/src/cs2/target.rs
@@ -57,6 +57,7 @@ impl CS2 {
         let aimbot_config = self.aimbot_config(config);
         let targeting_mode = &aimbot_config.targeting_mode;
         let max_fov = aimbot_config.fov;
+        let strict_occlusion = aimbot_config.smoke_wall_check;
         let is_custom_mode = self.is_custom_game_mode();
 
         let mut best_fov = 360.0;
@@ -122,6 +123,9 @@ impl CS2 {
             }
 
             let head_position = player.bone_position(self, Bones::Head.u64());
+            if strict_occlusion && !self.is_path_clear(eye_position, head_position) {
+                continue;
+            }
             let distance = eye_position.distance(head_position);
             let angle = self.angle_to_target(&local_player, &head_position, &aim_punch);
             let fov = angles_to_fov(&view_angles, &angle);
@@ -153,20 +157,28 @@ impl CS2 {
 
         // update target angle
         let mut smallest_fov = 360.0;
+        let mut found_bone = false;
         let target = self.target.player.as_ref().unwrap();
         for bone in Bones::iter() {
             let bone_position = target.bone_position(self, bone.u64());
+            if strict_occlusion && !self.is_path_clear(eye_position, bone_position) {
+                continue;
+            }
             let distance = eye_position.distance(bone_position);
             let angle = self.angle_to_target(&local_player, &bone_position, &aim_punch);
             let fov = angles_to_fov(&view_angles, &angle);
 
             if fov < smallest_fov {
                 smallest_fov = fov;
+                found_bone = true;
 
                 self.target.angle = angle;
                 self.target.distance = distance;
                 self.target.bone_index = bone.u64();
             }
+        }
+        if !found_bone {
+            self.target.reset();
         }
         /*
         let head_position = self.get_bone_position(process, self.target.pawn, Bones::Head.u64());

--- a/src/game.rs
+++ b/src/game.rs
@@ -76,6 +76,7 @@ impl GameManager {
     pub fn run(&mut self) {
         self.send_game_message(Message::GameStatus(GameStatus::NotStarted));
         let mut previous_status = GameStatus::NotStarted;
+        let mut next_data_tick = Instant::now();
         loop {
             let start = Instant::now();
             while let Ok(message) = self.rx.try_recv() {
@@ -98,10 +99,15 @@ impl GameManager {
                     previous_status = GameStatus::Working;
                 }
                 self.game.run(&self.config, &mut self.mouse);
-                let mut data = self.data.lock();
-                self.game.data(&self.config, &mut data);
+                let now = Instant::now();
+                if now >= next_data_tick {
+                    let mut data = self.data.lock();
+                    self.game.data(&self.config, &mut data);
+                    next_data_tick = now + data_loop_duration(&self.config);
+                }
             } else {
                 *self.data.lock() = Data::default();
+                next_data_tick = Instant::now();
             }
 
             if is_valid {
@@ -127,4 +133,9 @@ impl GameManager {
             self.config = *config;
         }
     }
+}
+
+fn data_loop_duration(config: &Config) -> std::time::Duration {
+    let hz = config.hud.data_refresh_rate.clamp(20, 240);
+    std::time::Duration::from_micros(1_000_000 / hz)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,10 +30,14 @@ mod ui;
 compile_error!("only linux is supported.");
 
 fn main() {
+    let debug_logging = std::env::var("DEADLOCKED_DEBUG")
+        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
     Logger::install(
         LoggerOptions::default()
             .file("deadlocked.log")
-            .debug(true)
+            .debug(debug_logging)
             .truncate(true)
             .module(module_path!()),
     );

--- a/src/os/crash.rs
+++ b/src/os/crash.rs
@@ -2,12 +2,16 @@ use std::{
     backtrace::Backtrace,
     collections::HashMap,
     panic::{self, PanicHookInfo},
+    path::PathBuf,
     process::Command,
     sync::atomic::{AtomicBool, Ordering},
     time::Duration,
 };
 
+use serde::Deserialize;
 use utils::log;
+
+use crate::config::{CONFIG_PATH, DEFAULT_CONFIG_NAME};
 
 pub fn install_crash_handler() {
     let default_hook = panic::take_hook();
@@ -21,6 +25,11 @@ const TIMEOUT_DURATION: Duration = Duration::from_secs(2);
 static SENT_REPORT: AtomicBool = AtomicBool::new(false);
 fn crash_handler(panic_info: &PanicHookInfo) {
     if SENT_REPORT.swap(true, Ordering::SeqCst) {
+        return;
+    }
+
+    if !telemetry_enabled() {
+        log::info!("crash telemetry disabled, skipping report");
         return;
     }
 
@@ -56,6 +65,10 @@ fn crash_handler(panic_info: &PanicHookInfo) {
 const UNKNOWN: &str = "unknown";
 
 pub fn info() {
+    if !telemetry_enabled() {
+        return;
+    }
+
     let hwid = hwid();
     let kernel = std::fs::read_to_string("/proc/sys/kernel/osrelease")
         .unwrap_or(UNKNOWN.to_owned())
@@ -150,4 +163,45 @@ fn git_commit() -> String {
             }
         })
         .unwrap_or(UNKNOWN.to_owned())
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+struct TelemetryFileConfig {
+    misc: TelemetryMiscConfig,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+struct TelemetryMiscConfig {
+    telemetry_enabled: bool,
+}
+
+impl Default for TelemetryMiscConfig {
+    fn default() -> Self {
+        Self {
+            telemetry_enabled: true,
+        }
+    }
+}
+
+fn telemetry_enabled() -> bool {
+    if let Ok(value) = std::env::var("DEADLOCKED_TELEMETRY") {
+        let normalized = value.trim().to_ascii_lowercase();
+        if matches!(normalized.as_str(), "0" | "false" | "no" | "off") {
+            return false;
+        }
+        if matches!(normalized.as_str(), "1" | "true" | "yes" | "on") {
+            return true;
+        }
+    }
+
+    let config_path: PathBuf = CONFIG_PATH.join(DEFAULT_CONFIG_NAME);
+    let Ok(contents) = std::fs::read_to_string(config_path) else {
+        return true;
+    };
+    let Ok(config) = toml::from_str::<TelemetryFileConfig>(&contents) else {
+        return true;
+    };
+    config.misc.telemetry_enabled
 }

--- a/src/os/mouse.rs
+++ b/src/os/mouse.rs
@@ -91,6 +91,29 @@ const SYN_REPORT: u16 = 0x00;
 const AXIS_X: u16 = 0x00;
 const AXIS_Y: u16 = 0x01;
 const BTN_LEFT: u16 = 0x110;
+const KEY_W: u16 = 17;
+const KEY_A: u16 = 30;
+const KEY_S: u16 = 31;
+const KEY_D: u16 = 32;
+
+#[derive(Debug, Clone, Copy)]
+pub enum MovementKey {
+    W,
+    A,
+    S,
+    D,
+}
+
+impl MovementKey {
+    fn code(self) -> u16 {
+        match self {
+            Self::W => KEY_W,
+            Self::A => KEY_A,
+            Self::S => KEY_S,
+            Self::D => KEY_D,
+        }
+    }
+}
 
 pub struct Mouse {
     file: File,
@@ -118,6 +141,10 @@ impl Mouse {
             ui_set_relbit(fd, AXIS_Y as u64).map_err(|e| e.to_string())?;
 
             ui_set_keybit(fd, BTN_LEFT as u64).map_err(|e| e.to_string())?;
+            ui_set_keybit(fd, KEY_W as u64).map_err(|e| e.to_string())?;
+            ui_set_keybit(fd, KEY_A as u64).map_err(|e| e.to_string())?;
+            ui_set_keybit(fd, KEY_S as u64).map_err(|e| e.to_string())?;
+            ui_set_keybit(fd, KEY_D as u64).map_err(|e| e.to_string())?;
 
             ui_dev_setup(fd, &DEVICE_SETUP).map_err(|e| e.to_string())?;
             ui_dev_create(fd).map_err(|e| e.to_string())?;
@@ -171,7 +198,19 @@ impl Mouse {
         self.key(0);
     }
 
+    pub fn movement_press(&mut self, key: MovementKey) {
+        self.send_key_event(key.code(), 1);
+    }
+
+    pub fn movement_release(&mut self, key: MovementKey) {
+        self.send_key_event(key.code(), 0);
+    }
+
     fn key(&mut self, pressed: i32) {
+        self.send_key_event(BTN_LEFT, pressed);
+    }
+
+    fn send_key_event(&mut self, code: u16, pressed: i32) {
         let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
         let time = Timeval {
             seconds: now.as_secs(),
@@ -181,7 +220,7 @@ impl Mouse {
         let press = InputEvent {
             time,
             event_type: EV_KEY,
-            code: BTN_LEFT,
+            code,
             value: pressed,
         };
 

--- a/src/os/process.rs
+++ b/src/os/process.rs
@@ -203,15 +203,24 @@ impl Process {
     }
 
     pub fn read_string_uncached(&self, address: u64) -> String {
-        let mut bytes = Vec::with_capacity(8);
-        let mut i = address;
-        loop {
-            let c = self.read::<u8>(i);
-            if c == 0 {
+        const CHUNK_SIZE: usize = 64;
+        const MAX_LENGTH: usize = 256;
+
+        let mut bytes = Vec::with_capacity(CHUNK_SIZE);
+        let mut offset = 0_u64;
+
+        while bytes.len() < MAX_LENGTH {
+            let remaining = MAX_LENGTH - bytes.len();
+            let read_len = remaining.min(CHUNK_SIZE);
+            let chunk = self.read_vec(address + offset, read_len);
+
+            if let Some(null_index) = chunk.iter().position(|&byte| byte == 0) {
+                bytes.extend_from_slice(&chunk[..null_index]);
                 break;
             }
-            bytes.push(c);
-            i += 1;
+
+            bytes.extend_from_slice(&chunk);
+            offset += read_len as u64;
         }
 
         String::from_utf8(bytes).unwrap_or_default()
@@ -224,6 +233,7 @@ impl Process {
     }
 
     pub fn module_base_address(&self, module_name: &str) -> Option<u64> {
+        let target_name = module_name.rsplit('/').next().unwrap_or(module_name);
         let Ok(maps) = File::open(format!("/proc/{}/maps", self.pid)) else {
             return None;
         };
@@ -231,7 +241,12 @@ impl Process {
             let Ok(line) = line else {
                 continue;
             };
-            if !line.contains(module_name) {
+            let path = line.split_whitespace().last().unwrap_or_default();
+            let file_name = path.rsplit('/').next().unwrap_or(path);
+            let module_matches = file_name == target_name
+                || file_name.starts_with(&format!("{target_name}."))
+                || path.contains(&format!("/{target_name}"));
+            if !module_matches {
                 continue;
             }
             let Some((address, _)) = line.split_once('-') else {
@@ -240,10 +255,10 @@ impl Process {
             let Ok(address) = u64::from_str_radix(address, 16) else {
                 continue;
             };
-            log::debug!("found module {module_name} at {address:X}");
+            log::debug!("found module {target_name} at {address:X}");
             return Some(address);
         }
-        log::warn!("module {module_name} not found");
+        log::debug!("module {target_name} is not mapped in process {}", self.pid);
         None
     }
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1,6 +1,8 @@
 use std::{
     collections::HashMap,
-    path::PathBuf,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -28,14 +30,12 @@ use crate::{
     },
 };
 
-const FRAME_RATE: u64 = 120;
-const FRAME_DURATION: Duration = Duration::from_micros(1_000_000 / FRAME_RATE);
-
 pub struct App {
     pub gui: Option<WindowContext>,
     pub overlay: Option<WindowContext>,
     pub clipboard: Clipboard,
     next_frame_time: Instant,
+    next_kde_check: Instant,
 
     pub tx: Sender<Envelope>,
     pub rx: Receiver<Message>,
@@ -44,6 +44,10 @@ pub struct App {
     pub game_status: GameStatus,
     pub radar_status: RadarStatus,
     pub display_scale: f32,
+    pub overlay_window_pos: Option<(i32, i32)>,
+    pub overlay_window_size: Option<(u32, u32)>,
+    pub overlay_visible: Option<bool>,
+    pub kde_compositing_active: bool,
     pub trails: HashMap<u64, Trail>,
     pub player_sounds: HashMap<u64, (Instant, SoundType)>,
 
@@ -78,7 +82,8 @@ impl App {
             overlay: None,
 
             clipboard: Clipboard::new().unwrap(),
-            next_frame_time: Instant::now() + FRAME_DURATION,
+            next_frame_time: Instant::now() + frame_duration(&config),
+            next_kde_check: Instant::now(),
 
             tx,
             rx,
@@ -91,6 +96,10 @@ impl App {
             game_status: GameStatus::NotStarted,
             radar_status: RadarStatus::Disconnected,
             display_scale: 1.0,
+            overlay_window_pos: None,
+            overlay_window_size: None,
+            overlay_visible: None,
+            kde_compositing_active: true,
             trails: HashMap::new(),
             player_sounds: HashMap::new(),
 
@@ -119,6 +128,8 @@ impl App {
     }
 
     fn create_window(&mut self, event_loop: &winit::event_loop::ActiveEventLoop) {
+        configure_kde_compositor_policy();
+
         let gui = WindowContext::new(event_loop, false, self.config.accent_color);
         let overlay = WindowContext::new(event_loop, true, self.config.accent_color);
 
@@ -127,26 +138,239 @@ impl App {
 
         self.gui = Some(gui);
         self.overlay = Some(overlay);
+        self.refresh_kde_compositor_state();
+        self.set_overlay_visible(true);
     }
+
+    pub fn overlay_allowed(&self) -> bool {
+        !is_kde_session() || self.kde_compositing_active
+    }
+
+    pub fn set_overlay_visible(&mut self, visible: bool) {
+        if self.overlay_visible == Some(visible) {
+            return;
+        }
+        if let Some(overlay) = &self.overlay {
+            overlay.window().set_visible(visible);
+        }
+        self.overlay_visible = Some(visible);
+    }
+
+    fn refresh_kde_compositor_state(&mut self) {
+        if !is_kde_session() {
+            self.kde_compositing_active = true;
+            return;
+        }
+
+        let now = Instant::now();
+        if now < self.next_kde_check {
+            return;
+        }
+        self.next_kde_check = now + Duration::from_secs(5);
+
+        let was_active = self.kde_compositing_active;
+        let Some(active) = query_kde_compositing_active() else {
+            return;
+        };
+        self.kde_compositing_active = active;
+
+        if active {
+            return;
+        }
+
+        if was_active {
+            log::warn!("KWin compositing is disabled, re-applying overlay compositor policy");
+        }
+        configure_kde_compositor_policy();
+        if let Some(active_after) = query_kde_compositing_active() {
+            self.kde_compositing_active = active_after;
+        }
+    }
+}
+
+fn is_kde_session() -> bool {
+    let desktop = std::env::var("XDG_CURRENT_DESKTOP")
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    desktop.contains("kde")
+        || desktop.contains("plasma")
+        || std::env::var_os("KDE_FULL_SESSION").is_some()
+        || std::env::var_os("KDE_SESSION_VERSION").is_some()
+}
+
+fn configure_kde_compositor_policy() {
+    if !is_kde_session() {
+        return;
+    }
+
+    let base_config = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")));
+    let Some(config_dir) = base_config else {
+        return;
+    };
+
+    let kwinrc_path = config_dir.join("kwinrc");
+    if !set_kwin_block_compositing_with_kwriteconfig(&kwinrc_path) {
+        let _ = set_kwin_block_compositing_with_file_patch(&kwinrc_path);
+    }
+
+    request_kwin_reconfigure();
+}
+
+fn set_kwin_block_compositing_with_kwriteconfig(kwinrc_path: &Path) -> bool {
+    let file = kwinrc_path.to_string_lossy().to_string();
+    for binary in ["kwriteconfig6", "kwriteconfig5", "kwriteconfig"] {
+        let Ok(status) = Command::new(binary)
+            .args([
+                "--file",
+                &file,
+                "--group",
+                "Compositing",
+                "--key",
+                "WindowsBlockCompositing",
+                "false",
+            ])
+            .status()
+        else {
+            continue;
+        };
+
+        if status.success() {
+            return true;
+        }
+    }
+    false
+}
+
+fn set_kwin_block_compositing_with_file_patch(kwinrc_path: &Path) -> bool {
+    let content = fs::read_to_string(kwinrc_path).unwrap_or_default();
+    let mut changed = false;
+    let mut output = Vec::with_capacity(content.lines().count() + 4);
+    let mut in_compositing = false;
+    let mut saw_compositing_section = false;
+    let mut saw_block_key = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        let is_section = trimmed.starts_with('[') && trimmed.ends_with(']');
+
+        if is_section {
+            if in_compositing && !saw_block_key {
+                output.push(String::from("WindowsBlockCompositing=false"));
+                changed = true;
+            }
+            in_compositing = trimmed == "[Compositing]";
+            if in_compositing {
+                saw_compositing_section = true;
+                saw_block_key = false;
+            }
+            output.push(line.to_string());
+            continue;
+        }
+
+        if in_compositing && trimmed.starts_with("WindowsBlockCompositing=") {
+            saw_block_key = true;
+            if trimmed != "WindowsBlockCompositing=false" {
+                output.push(String::from("WindowsBlockCompositing=false"));
+                changed = true;
+            } else {
+                output.push(line.to_string());
+            }
+            continue;
+        }
+
+        output.push(line.to_string());
+    }
+
+    if saw_compositing_section && in_compositing && !saw_block_key {
+        output.push(String::from("WindowsBlockCompositing=false"));
+        changed = true;
+    }
+
+    if !saw_compositing_section {
+        if !output.last().is_some_and(|line| line.is_empty()) {
+            output.push(String::new());
+        }
+        output.push(String::from("[Compositing]"));
+        output.push(String::from("WindowsBlockCompositing=false"));
+        changed = true;
+    }
+
+    if !changed {
+        return true;
+    }
+
+    if let Some(parent) = kwinrc_path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+
+    fs::write(kwinrc_path, format!("{}\n", output.join("\n"))).is_ok()
+}
+
+fn request_kwin_reconfigure() {
+    let _ = Command::new("dbus-send")
+        .args([
+            "--session",
+            "--type=method_call",
+            "--dest=org.kde.KWin",
+            "/KWin",
+            "org.kde.KWin.reconfigure",
+        ])
+        .status();
+}
+
+fn query_kde_compositing_active() -> Option<bool> {
+    let output = Command::new("dbus-send")
+        .args([
+            "--session",
+            "--print-reply",
+            "--dest=org.kde.KWin",
+            "/Compositor",
+            "org.freedesktop.DBus.Properties.Get",
+            "string:org.kde.kwin.Compositing",
+            "string:active",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if stdout.contains("boolean true") {
+        Some(true)
+    } else if stdout.contains("boolean false") {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+fn frame_duration(config: &Config) -> Duration {
+    let hz = config.hud.overlay_refresh_rate.clamp(30, 360);
+    Duration::from_micros(1_000_000 / hz)
 }
 
 impl ApplicationHandler for App {
     fn new_events(&mut self, _event_loop: &winit::event_loop::ActiveEventLoop, cause: StartCause) {
         if let StartCause::ResumeTimeReached { .. } = cause {
+            self.refresh_kde_compositor_state();
+
             if let Some(window) = &self.gui {
                 window.window().request_redraw();
             }
             if let Some(window) = &self.overlay {
                 window.window().request_redraw();
             }
-            self.next_frame_time += FRAME_DURATION;
+            self.next_frame_time += frame_duration(&self.config);
         }
     }
 
     fn resumed(&mut self, event_loop: &winit::event_loop::ActiveEventLoop) {
         self.create_window(event_loop);
 
-        self.next_frame_time = Instant::now() + FRAME_DURATION;
+        self.next_frame_time = Instant::now() + frame_duration(&self.config);
         event_loop.set_control_flow(winit::event_loop::ControlFlow::WaitUntil(
             self.next_frame_time,
         ));
@@ -180,6 +404,7 @@ impl ApplicationHandler for App {
         } else {
             return;
         };
+        let is_gui_window = gui.window().id() == window_id;
 
         match event {
             WindowEvent::CloseRequested => event_loop.exit(),
@@ -190,9 +415,10 @@ impl ApplicationHandler for App {
                 event_loop.set_control_flow(winit::event_loop::ControlFlow::WaitUntil(
                     self.next_frame_time,
                 ));
-                gui.request_redraw();
-                overlay.request_redraw();
-                self.render();
+                // Render only once per frame from the GUI window event.
+                if is_gui_window {
+                    self.render();
+                }
             }
             _ => {
                 let event_response = self.gui.as_mut().unwrap().process_event(&event);

--- a/src/ui/gui/aimbot.rs
+++ b/src/ui/gui/aimbot.rs
@@ -2,6 +2,7 @@ use egui::{DragValue, Ui};
 use strum::IntoEnumIterator as _;
 
 use crate::{
+    config::KeyMode,
     cs2::bones::Bones,
     ui::{
         app::App,
@@ -39,15 +40,6 @@ impl App {
 
     fn aimbot_left(&mut self, ui: &mut Ui) {
         collapsing_open(ui, "Aimbot", |ui| {
-            if keybind(
-                ui,
-                "aimbot_hotkey",
-                "Hotkey",
-                &mut self.config.aim.aimbot_hotkey,
-            ) {
-                self.send_config();
-            }
-
             if self.aimbot_tab == AimbotTab::Weapon
                 && checkbox_hover(
                     ui,
@@ -74,6 +66,20 @@ impl App {
                 &mut self.weapon_config().aimbot.mode,
             ) {
                 self.send_config();
+            }
+
+            let aimbot_mode = self.weapon_config().aimbot.mode.clone();
+            if aimbot_mode != KeyMode::Shoot {
+                if keybind(
+                    ui,
+                    "aimbot_hotkey",
+                    "Hotkey",
+                    &mut self.config.aim.aimbot_hotkey,
+                ) {
+                    self.send_config();
+                }
+            } else {
+                ui.label("Hotkey: not used in Shoot mode");
             }
 
             if checkbox_hover(
@@ -156,6 +162,19 @@ impl App {
             }
 
             if ui
+                .checkbox(
+                    &mut self.weapon_config().aimbot.smoke_wall_check,
+                    "Smoke/Wall Check",
+                )
+                .on_hover_text(
+                    "Requires parsed map BVH, clear geometry LOS, and no smoke between you and target",
+                )
+                .changed()
+            {
+                self.send_config();
+            }
+
+            if ui
                 .checkbox(&mut self.weapon_config().aimbot.flash_check, "Flash Check")
                 .changed()
             {
@@ -207,13 +226,27 @@ impl App {
                 self.send_config();
             }
 
-            if keybind(
+            if combo_box(
                 ui,
-                "triggerbot_hotkey",
-                "Hotkey",
-                &mut self.config.aim.triggerbot_hotkey,
+                "triggerbot_mode",
+                "Mode",
+                &mut self.weapon_config().triggerbot.mode,
             ) {
                 self.send_config();
+            }
+
+            let trigger_mode = self.weapon_config().triggerbot.mode.clone();
+            if trigger_mode != KeyMode::Shoot {
+                if keybind(
+                    ui,
+                    "triggerbot_hotkey",
+                    "Hotkey",
+                    &mut self.config.aim.triggerbot_hotkey,
+                ) {
+                    self.send_config();
+                }
+            } else {
+                ui.label("Hotkey: not used in Shoot mode");
             }
 
             ui.horizontal(|ui| {
@@ -228,15 +261,6 @@ impl App {
                 }
                 ui.label("Delay (ms)");
             });
-
-            if combo_box(
-                ui,
-                "triggerbot_mode",
-                "Mode",
-                &mut self.weapon_config().triggerbot.mode,
-            ) {
-                self.send_config();
-            }
 
             if ui
                 .checkbox(&mut self.weapon_config().triggerbot.head_only, "Head Only")
@@ -256,7 +280,67 @@ impl App {
                 {
                     self.send_config();
                 }
-                ui.label("Additional Duration (ms)");
+                ui.label("Press Duration (ms)");
+            });
+
+            if ui
+                .checkbox(
+                    &mut self.weapon_config().triggerbot.aim_assist,
+                    "Trigger Aim Assist",
+                )
+                .on_hover_text("Micro-adjusts aim before firing to reduce misses")
+                .changed()
+            {
+                self.send_config();
+            }
+
+            ui.horizontal(|ui| {
+                if ui
+                    .add(
+                        DragValue::new(&mut self.weapon_config().triggerbot.aim_fov)
+                            .range(0.1..=30.0)
+                            .suffix("°")
+                            .speed(0.02)
+                            .max_decimals(2),
+                    )
+                    .changed()
+                {
+                    self.send_config();
+                }
+                ui.label("Assist FOV");
+            });
+
+            ui.horizontal(|ui| {
+                if ui
+                    .add(
+                        DragValue::new(&mut self.weapon_config().triggerbot.fire_fov)
+                            .range(0.05..=10.0)
+                            .suffix("°")
+                            .speed(0.01)
+                            .max_decimals(2),
+                    )
+                    .on_hover_text("How close aim must be before triggerbot clicks")
+                    .changed()
+                {
+                    self.send_config();
+                }
+                ui.label("Fire FOV");
+            });
+
+            ui.horizontal(|ui| {
+                if ui
+                    .add(
+                        DragValue::new(&mut self.weapon_config().triggerbot.aim_smooth)
+                            .range(0.0..=20.0)
+                            .speed(0.05)
+                            .max_decimals(2),
+                    )
+                    .on_hover_text("Lower values aim faster during trigger adjustment")
+                    .changed()
+                {
+                    self.send_config();
+                }
+                ui.label("Assist Smooth");
             });
         });
 
@@ -265,6 +349,19 @@ impl App {
                 .checkbox(
                     &mut self.weapon_config().triggerbot.flash_check,
                     "Flash Check",
+                )
+                .changed()
+            {
+                self.send_config();
+            }
+
+            if ui
+                .checkbox(
+                    &mut self.weapon_config().triggerbot.smoke_wall_check,
+                    "Smoke/Wall Check",
+                )
+                .on_hover_text(
+                    "Requires parsed map BVH, clear geometry LOS, and no smoke between you and target",
                 )
                 .changed()
             {
@@ -286,7 +383,7 @@ impl App {
                     &mut self.weapon_config().triggerbot.velocity_check,
                     "Velocity Check",
                 )
-                .on_hover_text("Only shoot if the player moves slower than the specified threshold")
+                .on_hover_text("Only shoot if YOUR horizontal movement speed is below threshold")
                 .changed()
             {
                 self.send_config();
@@ -299,7 +396,7 @@ impl App {
                             .range(0..=5000),
                     )
                     .on_hover_text(
-                        "Maximum velocity at which the triggerbot can shoot (in CS2 Units)",
+                        "Maximum horizontal speed at which triggerbot can shoot (CS2 units/sec)",
                     )
                     .changed()
                 {

--- a/src/ui/gui/hud.rs
+++ b/src/ui/gui/hud.rs
@@ -175,6 +175,36 @@ impl App {
         });
 
         ui.collapsing("Advanced", |ui| {
+            ui.horizontal(|ui| {
+                if ui
+                    .add(
+                        DragValue::new(&mut self.config.hud.overlay_refresh_rate)
+                            .range(30..=360)
+                            .speed(1),
+                    )
+                    .on_hover_text("Overlay/UI render refresh rate")
+                    .changed()
+                {
+                    self.send_config();
+                }
+                ui.label("Overlay FPS");
+            });
+
+            ui.horizontal(|ui| {
+                if ui
+                    .add(
+                        DragValue::new(&mut self.config.hud.data_refresh_rate)
+                            .range(20..=240)
+                            .speed(1),
+                    )
+                    .on_hover_text("How often game data is sampled for ESP")
+                    .changed()
+                {
+                    self.send_config();
+                }
+                ui.label("Data FPS");
+            });
+
             if ui
                 .checkbox(&mut self.config.hud.debug, "Debug Overlay")
                 .changed()

--- a/src/ui/gui/unsafe.rs
+++ b/src/ui/gui/unsafe.rs
@@ -76,6 +76,78 @@ impl App {
     }
 
     fn unsafe_right(&mut self, ui: &mut Ui) {
+        collapsing_open(ui, "Aim", |ui| {
+            if ui
+                .checkbox(&mut self.config.misc.silent_aim, "Silent Aim")
+                .on_hover_text(
+                    "Applies angle writes before shot logic instead of only mouse movement",
+                )
+                .changed()
+            {
+                self.send_config();
+            }
+        });
+
+        collapsing_open(ui, "Privacy", |ui| {
+            if ui
+                .checkbox(
+                    &mut self.config.misc.telemetry_enabled,
+                    "Enable Crash Telemetry",
+                )
+                .on_hover_text(
+                    "Sends anonymous crash stack traces and basic system info for debugging",
+                )
+                .changed()
+            {
+                self.send_config();
+            }
+        });
+
+        collapsing_open(ui, "Movement", |ui| {
+            if ui
+                .checkbox(
+                    &mut self.config.misc.auto_counter_strafe,
+                    "Auto Counter-Strafe On Shot",
+                )
+                .changed()
+            {
+                self.send_config();
+            }
+
+            ui.horizontal(|ui| {
+                if ui
+                    .add(
+                        DragValue::new(&mut self.config.misc.counter_strafe_tap_ms)
+                            .range(1..=80)
+                            .speed(1),
+                    )
+                    .on_hover_text("How long each opposite movement key tap is held")
+                    .changed()
+                {
+                    self.send_config();
+                }
+                ui.label("Tap Duration (ms)");
+            });
+
+            ui.horizontal(|ui| {
+                if ui
+                    .add(
+                        DragValue::new(&mut self.config.misc.counter_strafe_speed_threshold)
+                            .range(0.0..=250.0)
+                            .speed(0.5)
+                            .max_decimals(1),
+                    )
+                    .on_hover_text(
+                        "Minimum local movement speed before velocity-based counter-strafe taps",
+                    )
+                    .changed()
+                {
+                    self.send_config();
+                }
+                ui.label("Speed Threshold");
+            });
+        });
+
         collapsing_open(ui, "FOV Changer", |ui| {
             if ui
                 .checkbox(&mut self.config.misc.fov_changer, "FOV Changer")

--- a/src/ui/overlay/hud.rs
+++ b/src/ui/overlay/hud.rs
@@ -1,4 +1,4 @@
-use egui::{Align2, Color32, Painter, Stroke, pos2};
+use egui::{Align2, Color32, FontId, Painter, Stroke, pos2};
 
 use crate::{
     cs2::entity::weapon_class::WeaponClass, data::Data, math::world_to_screen, ui::app::App,
@@ -7,13 +7,19 @@ use crate::{
 impl App {
     pub fn overlay_debug(&self, painter: &Painter, data: &Data) {
         if self.config.hud.debug {
-            painter.line(
-                vec![pos2(0.0, 0.0), pos2(data.window_size.x, data.window_size.y)],
-                Stroke::new(self.config.hud.line_width, Color32::WHITE),
-            );
-            painter.line(
-                vec![pos2(data.window_size.x, 0.0), pos2(0.0, data.window_size.y)],
-                Stroke::new(self.config.hud.line_width, Color32::WHITE),
+            painter.text(
+                pos2(8.0, 8.0),
+                Align2::LEFT_TOP,
+                format!(
+                    "in_game={} players={} friendlies={} entities={} map={}",
+                    data.in_game,
+                    data.players.len(),
+                    data.friendlies.len(),
+                    data.entities.len(),
+                    data.map_name
+                ),
+                FontId::proportional(self.config.hud.font_size),
+                Color32::WHITE,
             );
         }
     }

--- a/src/ui/overlay/mod.rs
+++ b/src/ui/overlay/mod.rs
@@ -29,9 +29,17 @@ impl App {
 
         self.update_trails();
         self.update_player_sounds();
-        let data = &self.data.lock();
+        let (window_position, window_size, overlay_visible) = {
+            let data = self.data.lock();
+            let overlay_visible = self.overlay_allowed() && (data.in_game || self.config.hud.debug);
+            (data.window_position, data.window_size, overlay_visible)
+        };
+        self.update_window(window_position, window_size, overlay_visible);
+        if !overlay_visible {
+            return;
+        }
 
-        self.update_window(data);
+        let data = &self.data.lock();
         self.overlay_debug(&painter, data);
 
         for player in &data.players {
@@ -87,23 +95,36 @@ impl App {
         self.grenade_manager(data, &painter);
     }
 
-    fn update_window(&self, data: &Data) {
+    fn update_window(
+        &mut self,
+        window_position: glam::Vec2,
+        window_size: glam::Vec2,
+        overlay_visible: bool,
+    ) {
+        self.set_overlay_visible(overlay_visible);
+        if !overlay_visible {
+            return;
+        }
+
         let Some(window) = &self.overlay else {
             return;
         };
 
-        window
-            .window()
-            .set_outer_position(winit::dpi::PhysicalPosition::new(
-                data.window_position.x,
-                data.window_position.y,
-            ));
-        let _ = window
-            .window()
-            .request_inner_size(winit::dpi::PhysicalSize::new(
-                data.window_size.x.max(1.0),
-                data.window_size.y.max(1.0),
-            ));
+        let new_pos = (window_position.x as i32, window_position.y as i32);
+        if self.overlay_window_pos != Some(new_pos) {
+            window
+                .window()
+                .set_outer_position(winit::dpi::PhysicalPosition::new(new_pos.0, new_pos.1));
+            self.overlay_window_pos = Some(new_pos);
+        }
+
+        let new_size = (window_size.x.max(1.0) as u32, window_size.y.max(1.0) as u32);
+        if self.overlay_window_size != Some(new_size) {
+            let _ = window
+                .window()
+                .request_inner_size(winit::dpi::PhysicalSize::new(new_size.0, new_size.1));
+            self.overlay_window_size = Some(new_size);
+        }
     }
 
     fn grenade_manager(&self, data: &Data, painter: &Painter) {

--- a/src/ui/window_context.rs
+++ b/src/ui/window_context.rs
@@ -3,6 +3,7 @@ use std::{num::NonZeroU32, sync::Arc};
 use egui::{Color32, FontData, FontDefinitions, Stroke, Style};
 use egui_glow::glow::{self, HasContext as _};
 use glutin::prelude::PossiblyCurrentGlContext;
+use nix::libc;
 use winit::platform::x11::{WindowAttributesExtX11, WindowType};
 
 use crate::ui::color::Colors;
@@ -30,16 +31,25 @@ impl WindowContext {
         use winit::raw_window_handle::HasWindowHandle as _;
 
         let winit_window_builder = if overlay {
-            winit::window::WindowAttributes::default()
+            let mut attributes = winit::window::WindowAttributes::default()
                 .with_decorations(false)
                 .with_inner_size(winit::dpi::PhysicalSize::new(1, 1))
                 .with_position(winit::dpi::PhysicalPosition::new(0, 0))
                 .with_resizable(true)
                 .with_transparent(true)
                 .with_window_level(winit::window::WindowLevel::AlwaysOnTop)
-                .with_override_redirect(true)
-                .with_x11_window_type(vec![WindowType::Tooltip])
-                .with_title("deadlocked_overlay")
+                .with_title("deadlocked_overlay");
+
+            if is_kde_session() {
+                attributes = attributes
+                    .with_override_redirect(true)
+                    .with_x11_window_type(vec![WindowType::Dock]);
+            } else {
+                attributes = attributes
+                    .with_override_redirect(true)
+                    .with_x11_window_type(vec![WindowType::Tooltip]);
+            }
+            attributes
         } else {
             winit::window::WindowAttributes::default()
                 .with_inner_size(winit::dpi::LogicalSize::new(750, 450))
@@ -122,6 +132,8 @@ impl WindowContext {
             .set_swap_interval(&gl_context, glutin::surface::SwapInterval::DontWait)
             .unwrap();
 
+        set_x11_compositor_hints(&window);
+
         if overlay {
             window.set_cursor_hittest(false).unwrap();
             window.set_outer_position(winit::dpi::PhysicalPosition::new(0, 0));
@@ -200,6 +212,109 @@ impl WindowContext {
     pub fn paint(&mut self) {
         self.egui_glow.paint(&self.window);
     }
+}
+
+fn set_x11_compositor_hints(window: &winit::window::Window) {
+    use winit::raw_window_handle::{
+        HasDisplayHandle as _, HasWindowHandle as _, RawDisplayHandle, RawWindowHandle,
+    };
+
+    let Ok(display_handle) = window.display_handle() else {
+        return;
+    };
+    let Ok(window_handle) = window.window_handle() else {
+        return;
+    };
+
+    let (display, x_window) = match (display_handle.as_raw(), window_handle.as_raw()) {
+        (RawDisplayHandle::Xlib(display), RawWindowHandle::Xlib(window)) => {
+            let Some(display) = display.display else {
+                return;
+            };
+            (display.as_ptr(), window.window)
+        }
+        _ => return,
+    };
+
+    unsafe {
+        let net_wm_bypass = x11_intern_atom(display, "_NET_WM_BYPASS_COMPOSITOR");
+        let kde_block = x11_intern_atom(display, "_KDE_NET_WM_BLOCK_COMPOSITING");
+        let cardinal = x11_intern_atom(display, "CARDINAL");
+        if cardinal == 0 {
+            return;
+        }
+
+        // 2 = compositing should not be bypassed for this window.
+        let bypass_value: libc::c_ulong = 2;
+        if net_wm_bypass != 0 {
+            XChangeProperty(
+                display,
+                x_window,
+                net_wm_bypass,
+                cardinal,
+                32,
+                PROP_MODE_REPLACE,
+                (&bypass_value as *const libc::c_ulong).cast(),
+                1,
+            );
+        }
+
+        // KDE-specific hint; 0 disables compositor blocking for this window.
+        let kde_block_value: libc::c_ulong = 0;
+        if kde_block != 0 {
+            XChangeProperty(
+                display,
+                x_window,
+                kde_block,
+                cardinal,
+                32,
+                PROP_MODE_REPLACE,
+                (&kde_block_value as *const libc::c_ulong).cast(),
+                1,
+            );
+        }
+
+        XFlush(display);
+    }
+}
+
+fn is_kde_session() -> bool {
+    let desktop = std::env::var("XDG_CURRENT_DESKTOP")
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    desktop.contains("kde")
+        || desktop.contains("plasma")
+        || std::env::var_os("KDE_FULL_SESSION").is_some()
+        || std::env::var_os("KDE_SESSION_VERSION").is_some()
+}
+
+const PROP_MODE_REPLACE: libc::c_int = 0;
+
+#[link(name = "X11")]
+unsafe extern "C" {
+    fn XInternAtom(
+        display: *mut libc::c_void,
+        atom_name: *const libc::c_char,
+        only_if_exists: libc::c_int,
+    ) -> libc::c_ulong;
+    fn XChangeProperty(
+        display: *mut libc::c_void,
+        w: libc::c_ulong,
+        property: libc::c_ulong,
+        type_: libc::c_ulong,
+        format: libc::c_int,
+        mode: libc::c_int,
+        data: *const libc::c_uchar,
+        nelements: libc::c_int,
+    );
+    fn XFlush(display: *mut libc::c_void) -> libc::c_int;
+}
+
+unsafe fn x11_intern_atom(display: *mut libc::c_void, atom_name: &str) -> libc::c_ulong {
+    let Ok(atom_name) = std::ffi::CString::new(atom_name) else {
+        return 0;
+    };
+    unsafe { XInternAtom(display, atom_name.as_ptr(), 0) }
 }
 
 impl Drop for WindowContext {


### PR DESCRIPTION
1. tightened aim/trigger behavior for smoother and less janky shooting behaviour
2. added shot-time auto counter-strafe (manual left-click + triggerbot path) with configurable tap/speed thresholds
3. added trigger-specific aim-assist knobs and improved repeated-fire timing for pistols/semi-auto behavior
4. added silent aim (may not work, beta, in unsafe tab) + normal aim paths working and configurable
5. added privacy toggle to opt out of crash/system telemetry (misc.telemetry_enabled)
6. telemetry is now gated in crash + info reporting code; also supports DEADLOCKED_TELEMETRY env override
7. added shoot mode, its a new aimbot mode for people with a mouse with no side buttons, tries to make best effort at aim with left click