### PR TITLE
Fix entity list early return and friendly esp not working on official maps.

### DIFF
--- a/src/cs2/entity/mod.rs
+++ b/src/cs2/entity/mod.rs
@@ -174,7 +174,7 @@ impl CS2 {
 
                     if name.starts_with("weapon_") {
                         if self.entity_has_owner(entity) {
-                            return;
+                            continue;
                         }
 
                         let weapon = Weapon::from_entity(entity, self);

--- a/src/ui/gui/player.rs
+++ b/src/ui/gui/player.rs
@@ -56,12 +56,7 @@ impl App {
                 self.send_config();
             }
 
-            if checkbox_hover(
-                ui,
-                "Show Friendlies",
-                "Only active in custom game modes (workshop/custom maps)",
-                &mut self.config.player.show_friendlies,
-            ) {
+            if checkbox(ui, "Show Friendlies", &mut self.config.player.show_friendlies) {
                 self.send_config();
             }
 

--- a/src/ui/overlay/mod.rs
+++ b/src/ui/overlay/mod.rs
@@ -40,7 +40,7 @@ impl App {
             }
         }
 
-        if self.config.player.show_friendlies && data.is_custom_mode {
+        if self.config.player.show_friendlies {
             for player in &data.friendlies {
                 if data.esp_active {
                     self.draw_player(&painter, player, data);


### PR DESCRIPTION
1. The entity code had changed from continue to return in the latest file update making a weapon without owner hold back all the next entities weapons/nades etc.
2. Should entities be locked away on the official maps if the checkbox exists to toggle them? I use friendly esp to see where my teammates are but I understand how this can clutter the view on official matches since there isn't any color differentiation at the moment. Perhaps should it be an entry under a combo in the future since I completely missed the hover requirement in the UI and only noticed it now in the code, you can revert it if needed. 