### PR TITLE
RCS: replace smooth for x/y strength settings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use egui::Color32;
+use glam::Vec2;
 use serde::{Deserialize, Serialize};
 use strum::{EnumIter, IntoEnumIterator};
 
@@ -148,8 +149,7 @@ impl Default for AimbotConfig {
 pub struct RcsConfig {
     pub enable_override: bool,
     pub enabled: bool,
-    pub x_strength: f32,
-    pub y_strength: f32,
+    pub strength: Vec2,
 }
 
 impl Default for RcsConfig {
@@ -157,8 +157,7 @@ impl Default for RcsConfig {
         Self {
             enable_override: false,
             enabled: false,
-            x_strength: 0.5,
-            y_strength: 0.5,
+            strength: Vec2::splat(0.5),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -148,7 +148,8 @@ impl Default for AimbotConfig {
 pub struct RcsConfig {
     pub enable_override: bool,
     pub enabled: bool,
-    pub smooth: f32,
+    pub x_strength: f32,
+    pub y_strength: f32,
 }
 
 impl Default for RcsConfig {
@@ -156,7 +157,8 @@ impl Default for RcsConfig {
         Self {
             enable_override: false,
             enabled: false,
-            smooth: 0.3,
+            x_strength: 0.5,
+            y_strength: 0.5,
         }
     }
 }

--- a/src/cs2/features/rcs.rs
+++ b/src/cs2/features/rcs.rs
@@ -57,7 +57,10 @@ impl CS2 {
             (aim_punch.y - self.recoil.previous.y) / sensitivity * 100.0,
             -(aim_punch.x - self.recoil.previous.x) / sensitivity * 100.0,
         ) + self.recoil.unaccounted;
-        let mouse_angle = mouse_angle / (config.smooth + 1.0).clamp(1.0, 2.0);
+        let mouse_angle = Vec2::new(
+            mouse_angle.x * config.x_strength.clamp(0.0, 1.0),
+            mouse_angle.y * config.y_strength.clamp(0.0, 1.0),
+        );
 
         self.recoil.unaccounted = Vec2::ZERO;
 

--- a/src/cs2/features/rcs.rs
+++ b/src/cs2/features/rcs.rs
@@ -57,10 +57,7 @@ impl CS2 {
             (aim_punch.y - self.recoil.previous.y) / sensitivity * 100.0,
             -(aim_punch.x - self.recoil.previous.x) / sensitivity * 100.0,
         ) + self.recoil.unaccounted;
-        let mouse_angle = Vec2::new(
-            mouse_angle.x * config.x_strength.clamp(0.0, 1.0),
-            mouse_angle.y * config.y_strength.clamp(0.0, 1.0),
-        );
+        let mouse_angle = mouse_angle * config.strength.clamp(Vec2::ZERO, Vec2::ONE);
 
         self.recoil.unaccounted = Vec2::ZERO;
 

--- a/src/ui/gui/aimbot.rs
+++ b/src/ui/gui/aimbot.rs
@@ -325,16 +325,29 @@ impl App {
             ui.horizontal(|ui| {
                 if ui
                     .add(
-                        DragValue::new(&mut self.weapon_config().rcs.smooth)
+                        DragValue::new(&mut self.weapon_config().rcs.x_strength)
                             .range(0.0..=1.0)
-                            .speed(0.02),
+                            .speed(0.01),
                     )
-                    .on_hover_text("Lower values mean more direct recoil control")
                     .changed()
                 {
                     self.send_config();
                 }
-                ui.label("RCS Smooth");
+                ui.label("X Strength");
+            });
+
+            ui.horizontal(|ui| {
+                if ui
+                    .add(
+                        DragValue::new(&mut self.weapon_config().rcs.y_strength)
+                            .range(0.0..=1.0)
+                            .speed(0.01),
+                    )
+                    .changed()
+                {
+                    self.send_config();
+                }
+                ui.label("Y Strength");
             });
         });
     }

--- a/src/ui/gui/aimbot.rs
+++ b/src/ui/gui/aimbot.rs
@@ -322,33 +322,29 @@ impl App {
                 self.send_config();
             }
 
-            ui.horizontal(|ui| {
-                if ui
-                    .add(
-                        DragValue::new(&mut self.weapon_config().rcs.x_strength)
+            if ui
+                .horizontal(|ui| {
+                    let rcs = &mut self.weapon_config().rcs;
+                    let x = ui.add(
+                        DragValue::new(&mut rcs.strength.x)
+                            .prefix("X ")
                             .range(0.0..=1.0)
                             .speed(0.01),
-                    )
-                    .changed()
-                {
-                    self.send_config();
-                }
-                ui.label("X Strength");
-            });
-
-            ui.horizontal(|ui| {
-                if ui
-                    .add(
-                        DragValue::new(&mut self.weapon_config().rcs.y_strength)
+                    );
+                    let y = ui.add(
+                        DragValue::new(&mut rcs.strength.y)
+                            .prefix("Y ")
                             .range(0.0..=1.0)
                             .speed(0.01),
-                    )
-                    .changed()
-                {
-                    self.send_config();
-                }
-                ui.label("Y Strength");
-            });
+                    );
+                    ui.label("Strength");
+                    x | y
+                })
+                .inner
+                .changed()
+            {
+                self.send_config();
+            }
         });
     }
 }


### PR DESCRIPTION
Refactors standalone RCS smoothing into X/Y strength controls.

The previous smooth setting was limited to 0 - 1, but it divided recoil movement by (smooth + 1), making the effective range 50% - 100% instead of actually 0% - 100% range. 

This change fixes that and also gives the user more control over the rcs.