### PR TITLE
Add checkbox for showing Aimbot binds

### DIFF
--- a/src/ui/gui/hud.rs
+++ b/src/ui/gui/hud.rs
@@ -95,6 +95,10 @@ impl App {
                 self.send_config();
             }
 
+            if checkbox(ui, "Show Aimbot Binds", &mut self.config.hud.keybind_list) {
+                self.send_config();
+            }
+
             if checkbox(
                 ui,
                 "Sniper Crosshair",


### PR DESCRIPTION
Now the menu have the config for Aimbot and triggerbot keybinds:
<img width="227" height="143" alt="image" src="https://github.com/user-attachments/assets/4201f1f4-33e1-476d-8737-eb47e37e9af9" />
