### PR TITLE
Allow unbinding keybinds with Esc

### DIFF
--- a/src/cs2/input.rs
+++ b/src/cs2/input.rs
@@ -32,11 +32,17 @@ impl Input {
     }
 
     pub fn is_key_pressed(&self, key: KeyCode) -> bool {
+        if key == KeyCode::Unbound {
+            return false;
+        }
         self.current_state.get(key.usize()).unwrap_or(false)
     }
 
     #[allow(dead_code)]
     pub fn key_just_pressed(&self, key: KeyCode) -> bool {
+        if key == KeyCode::Unbound {
+            return false;
+        }
         !self.previous_state.get(key.usize()).unwrap_or(false)
             && self.current_state.get(key.usize()).unwrap_or(false)
     }

--- a/src/cs2/input.rs
+++ b/src/cs2/input.rs
@@ -32,7 +32,7 @@ impl Input {
     }
 
     pub fn is_key_pressed(&self, key: KeyCode) -> bool {
-        if key == KeyCode::Unbound {
+        if key == KeyCode::None {
             return false;
         }
         self.current_state.get(key.usize()).unwrap_or(false)
@@ -40,7 +40,7 @@ impl Input {
 
     #[allow(dead_code)]
     pub fn key_just_pressed(&self, key: KeyCode) -> bool {
-        if key == KeyCode::Unbound {
+        if key == KeyCode::None {
             return false;
         }
         !self.previous_state.get(key.usize()).unwrap_or(false)

--- a/src/cs2/key_codes.rs
+++ b/src/cs2/key_codes.rs
@@ -5,6 +5,7 @@ use strum::EnumIter;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, EnumIter, Serialize, Deserialize)]
 pub enum KeyCode {
+    Unbound = 0,
     Num0 = 1,
     Num1,
     Num2,
@@ -115,6 +116,7 @@ impl KeyCode {
             "Mouse5" => KeyCode::Mouse5,
             "MouseWheelUp" => KeyCode::MouseWheelUp,
             "MouseWheelDown" => KeyCode::MouseWheelDown,
+            "Unbound" => KeyCode::Unbound,
             _ => return None,
         })
     }

--- a/src/cs2/key_codes.rs
+++ b/src/cs2/key_codes.rs
@@ -5,7 +5,7 @@ use strum::EnumIter;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, EnumIter, Serialize, Deserialize)]
 pub enum KeyCode {
-    Unbound = 0,
+    None = 0,
     Num0 = 1,
     Num1,
     Num2,
@@ -116,7 +116,7 @@ impl KeyCode {
             "Mouse5" => KeyCode::Mouse5,
             "MouseWheelUp" => KeyCode::MouseWheelUp,
             "MouseWheelDown" => KeyCode::MouseWheelDown,
-            "Unbound" => KeyCode::Unbound,
+            "None" => KeyCode::None,
             _ => return None,
         })
     }

--- a/src/ui/gui/helpers.rs
+++ b/src/ui/gui/helpers.rs
@@ -165,7 +165,10 @@ impl<'gui> Widget for Keybind<'gui> {
             });
 
             if let Some(input) = input {
-                if input != KeyCode::Escape {
+                if input == KeyCode::Escape {
+                    *self.keycode = KeyCode::Unbound;
+                    response.mark_changed();
+                } else {
                     *self.keycode = input;
                     response.mark_changed();
                 }

--- a/src/ui/gui/helpers.rs
+++ b/src/ui/gui/helpers.rs
@@ -166,7 +166,7 @@ impl<'gui> Widget for Keybind<'gui> {
 
             if let Some(input) = input {
                 if input == KeyCode::Escape {
-                    *self.keycode = KeyCode::Unbound;
+                    *self.keycode = KeyCode::None;
                     response.mark_changed();
                 } else {
                     *self.keycode = input;


### PR DESCRIPTION
Add `KeyCode::Unbound` and make pressing Esc while assigning a key clear the binding.
Input checks ignore `Unbound` so cleared binds no longer trigger.