### PR TITLE
sync rcs with the aimbot

### DIFF
--- a/src/cs2/features/aimbot.rs
+++ b/src/cs2/features/aimbot.rs
@@ -109,6 +109,8 @@ impl CS2 {
         self.aim.inertia += (mouse_angles - self.aim.inertia) * alpha;
         mouse.move_rel(self.aim.inertia);
 
+        self.recoil.previous = local_player.aim_punch(self);
+
         true
     }
 }

--- a/src/cs2/features/rcs.rs
+++ b/src/cs2/features/rcs.rs
@@ -15,7 +15,7 @@ use crate::{
 
 #[derive(Debug)]
 pub struct Recoil {
-    previous: Vec2,
+    pub previous: Vec2,
     unaccounted: Vec2,
     velocity: Vec2,
     accel_history: VecDeque<Vec2>,


### PR DESCRIPTION
fixes bug when aimbot loses target and then rcs activates and does all the previous rcs again at once.



before:

https://github.com/user-attachments/assets/85ad90b3-5fe3-41d4-8a37-fb81e4fe133a



after:

https://github.com/user-attachments/assets/92838f04-b836-4860-8643-dca0e8a33b99

