### PR TITLE
add prioritized aimbot bones

### DIFF
--- a/src/config/aim.rs
+++ b/src/config/aim.rs
@@ -43,6 +43,7 @@ pub struct AimbotConfig {
     pub smooth: f32,
     pub inertia: f32,
     pub bones: Vec<Bones>,
+    pub prioritized_bones: Vec<Bones>,
     pub targeting_mode: TargetingMode,
 }
 
@@ -69,6 +70,7 @@ impl Default for AimbotConfig {
                 Bones::Spine1,
                 Bones::Hip,
             ],
+            prioritized_bones: vec![Bones::Head],
             targeting_mode: TargetingMode::Fov,
         }
     }

--- a/src/cs2/entity/player.rs
+++ b/src/cs2/entity/player.rs
@@ -486,6 +486,18 @@ impl Player {
         true
     }
 
+    pub fn bone_visible(&self, cs2: &CS2, local_player: &Player, bone: Bones) -> bool {
+        if let Some(bvh) = &cs2.bvh {
+            return bvh.has_line_of_sight(
+                local_player.eye_position(cs2),
+                self.bone_position(cs2, bone.u64()),
+            );
+        }
+
+        let spotted_mask = self.spotted_mask(cs2);
+        (spotted_mask & (1 << cs2.target.local_pawn_index)) != 0
+    }
+
     pub fn crosshair_entity(&self, cs2: &CS2) -> Option<Self> {
         let index: i32 = cs2
             .process

--- a/src/cs2/features/aimbot.rs
+++ b/src/cs2/features/aimbot.rs
@@ -1,9 +1,10 @@
 use glam::{Vec2, vec2};
 
 use crate::{
-    config::Config,
+    config::{Config, aim::AimbotConfig},
     cs2::{
         CS2,
+        bones::Bones,
         entity::{player::Player, weapon_class::WeaponClass},
     },
     math::{angles_to_fov, vec2_clamp},
@@ -63,34 +64,13 @@ impl CS2 {
             return false;
         }
 
-        let target_angle = {
-            let mut smallest_fov = 360.0;
-            let mut smallest_angle = glam::Vec2::ZERO;
-            for bone in &config.bones {
-                let bone_pos = target.bone_position(self, bone.u64());
-                let angle =
-                    self.angle_to_target(&local_player, &bone_pos, &self.target.previous_aim_punch);
-                let fov = angles_to_fov(&local_player.view_angles(self), &angle);
-                if fov < smallest_fov {
-                    smallest_fov = fov;
-                    smallest_angle = angle;
-                }
-            }
-
-            smallest_angle
+        let Some((target_angle, _target_distance)) =
+            self.best_aim_bone(config, target, &local_player)
+        else {
+            return false;
         };
 
         let view_angles = local_player.view_angles(self);
-        if angles_to_fov(&view_angles, &target_angle)
-            > (config.fov
-                * if config.distance_adjusted_fov {
-                    self.distance_scale(self.target.distance)
-                } else {
-                    1.0
-                })
-        {
-            return false;
-        }
 
         let mut aim_angles = view_angles - target_angle;
         if aim_angles.y < -180.0 {
@@ -112,5 +92,61 @@ impl CS2 {
         self.recoil.previous = local_player.aim_punch(self);
 
         true
+    }
+
+    fn best_aim_bone(
+        &self,
+        config: &AimbotConfig,
+        target: &Player,
+        local_player: &Player,
+    ) -> Option<(Vec2, f32)> {
+        self.best_aim_bone_from(config, target, local_player, &config.prioritized_bones)
+            .or_else(|| self.best_aim_bone_from(config, target, local_player, &config.bones))
+    }
+
+    fn best_aim_bone_from(
+        &self,
+        config: &AimbotConfig,
+        target: &Player,
+        local_player: &Player,
+        bones: &[Bones],
+    ) -> Option<(Vec2, f32)> {
+        let view_angles = local_player.view_angles(self);
+        let eye_position = local_player.eye_position(self);
+        let mut best = None;
+        let mut smallest_fov = 360.0;
+
+        for bone in bones {
+            if !config.bones.contains(bone) {
+                continue;
+            }
+
+            if config.visibility_check && !target.bone_visible(self, local_player, *bone) {
+                continue;
+            }
+
+            let bone_pos = target.bone_position(self, bone.u64());
+            let angle =
+                self.angle_to_target(local_player, &bone_pos, &self.target.previous_aim_punch);
+            let fov = angles_to_fov(&view_angles, &angle);
+            let distance = eye_position.distance(bone_pos);
+            let fov_limit = config.fov
+                * if config.distance_adjusted_fov {
+                    self.distance_scale(distance)
+                } else {
+                    1.0
+                };
+
+            if fov > fov_limit {
+                continue;
+            }
+
+            if fov < smallest_fov {
+                smallest_fov = fov;
+                best = Some((angle, distance));
+            }
+        }
+
+        best
     }
 }

--- a/src/ui/gui/aimbot.rs
+++ b/src/ui/gui/aimbot.rs
@@ -1,4 +1,4 @@
-use egui::{DragValue, Ui};
+use egui::{Button, DragValue, Ui};
 use strum::IntoEnumIterator as _;
 
 use crate::{
@@ -179,8 +179,38 @@ impl App {
                 if ui.selectable_label(index.is_some(), text).clicked() {
                     if let Some(index) = index {
                         self.weapon_config().aimbot.bones.remove(index);
+                        self.weapon_config()
+                            .aimbot
+                            .prioritized_bones
+                            .retain(|b| *b != bone);
                     } else {
                         self.weapon_config().aimbot.bones.push(bone);
+                    }
+                    self.send_config();
+                }
+            }
+        });
+
+        ui.collapsing("Prioritized Bones", |ui| {
+            for bone in Bones::iter() {
+                let text = format!("{:?}", bone);
+                let selected = self.weapon_config().aimbot.bones.contains(&bone);
+                let index = self
+                    .weapon_config()
+                    .aimbot
+                    .prioritized_bones
+                    .iter()
+                    .position(|b| *b == bone);
+
+                let clicked = ui
+                    .add_enabled(selected, Button::selectable(index.is_some(), text))
+                    .clicked();
+
+                if clicked {
+                    if let Some(index) = index {
+                        self.weapon_config().aimbot.prioritized_bones.remove(index);
+                    } else {
+                        self.weapon_config().aimbot.prioritized_bones.push(bone);
                     }
                     self.send_config();
                 }


### PR DESCRIPTION
## Summary

Adds prioritized aimbot bones.

## Changes

* Adds `prioritized_bones` to the aimbot config
* Adds a separate `Prioritized Bones` section under the normal `Bones` section
* Greys out prioritized bones that are not enabled in the normal bones list
* Removes a bone from the priority list when it is removed from the normal bones list
* Makes the aimbot prefer prioritized bones before falling back to other selected bones

## Notes

Existing visibility/BVH behavior appears to be nonfunctional despite no changes being made to those systems. This is reproducible by selecting an occluded bone, after which the aimbot still aims toward it. Disabling prioritized bones also does not prevent the aimbot from aiming through walls.
