### PR TITLE
signature-based global offsets at startup, aka: better offset finding

### DIFF
--- a/cheat/src/cs2/find_offsets.rs
+++ b/cheat/src/cs2/find_offsets.rs
@@ -2,7 +2,11 @@ use std::time::Instant;
 
 use crate::{
     constants::cs2,
-    cs2::{CS2, offsets::Offsets, schema::Schema},
+    cs2::{
+        CS2,
+        offsets::Offsets,
+        signatures,
+    },
 };
 
 impl CS2 {
@@ -26,9 +30,6 @@ impl CS2 {
         };
         offsets.interface.resource = resource_offset;
 
-        offsets.interface.entity =
-            self.process.read::<u64>(offsets.interface.resource + 0x50) + 0x10;
-
         let Some(cvar_address) = self
             .process
             .get_interface_offset(offsets.library.tier0, "VEngineCvar0")
@@ -37,6 +38,7 @@ impl CS2 {
             return None;
         };
         offsets.interface.cvar = cvar_address;
+
         let Some(input_address) = self
             .process
             .get_interface_offset(offsets.library.input, "InputSystemVersion0")
@@ -46,31 +48,18 @@ impl CS2 {
         };
         offsets.interface.input = input_address;
 
-        let Some(local_player) = self
-            .process
-            .scan("48 83 3D ? ? ? ? 00 0F 95 C0 C3", offsets.library.client)
-        else {
-            utils::warn!("could not find local player offset");
-            return None;
-        };
-        offsets.direct.local_player = self.process.get_relative_address(local_player, 0x03, 0x08);
+        let resolved = signatures::resolve(&self.process, &offsets.library)?;
+        let globals = resolved.globals;
+        let schema = resolved.schema;
+        offsets.direct = globals.direct;
+        offsets.interface.entity =
+            self.process.read::<u64>(offsets.interface.resource + 0x50) + 0x10;
+
         offsets.direct.button_state = self.process.read::<u32>(
             self.process
                 .get_interface_function(offsets.interface.input, 19)
                 + 0x14,
         ) as u64;
-
-        let Some(view_matrix) = self
-            .process
-            .scan("C6 83 ? ? 00 00 01 4C 8D 05", offsets.library.client)
-        else {
-            utils::warn!("could not find view matrix offset");
-            return None;
-        };
-
-        offsets.direct.view_matrix =
-            self.process
-                .get_relative_address(view_matrix + 0x0A, 0x0, 0x04);
 
         let Some(sdl_window) = self
             .process
@@ -83,55 +72,22 @@ impl CS2 {
         let sdl_window = self.process.read(sdl_window);
         offsets.direct.sdl_window = self.process.get_relative_address(sdl_window, 0x03, 0x07);
 
-        let Some(planted_c4) = self.process.scan(
-            "48 8D 35 ? ? ? ? 66 0F EF C0 C6 05 ? ? ? ? 01 48 8D 3D",
-            offsets.library.client,
-        ) else {
-            utils::warn!("could not find planted c4 offset");
-            return None;
-        };
-        offsets.direct.planted_c4 = self.process.get_relative_address(planted_c4, 0x03, 0x0E);
+        offsets.convar.sensitivity = globals.sensitivity;
+        if offsets.convar.sensitivity == 0 {
+            offsets.convar.sensitivity = self
+                .process
+                .get_convar(offsets.interface.cvar, "sensitivity")
+                .unwrap_or(0);
+        }
+        if offsets.convar.sensitivity == 0 {
+            utils::debug!("sensitivity not found, using default");
+        }
 
-        // xref "lobby_mapveto"
-        let Some(global_vars) = self.process.scan(
-            "48 8D 05 ? ? ? ? 48 8B 00 8B 48 ? E9",
-            offsets.library.client,
-        ) else {
-            utils::warn!("could not find global vars offset");
-            return None;
-        };
-        offsets.direct.global_vars = self.process.get_relative_address(global_vars, 0x03, 0x07);
-
-        let Some(vphys_world) = self.process.scan(
-            "4c 8d 3d ? ? ? ? 49 8b 3f e8 ? ? ? ? 48 89 c2",
-            offsets.library.client,
-        ) else {
-            utils::warn!("could not find vphys_world offset");
-            return None;
-        };
-        // 0x0D + 4, 12, 20, 28
-        let vphys_world_global_ptr = self.process.get_relative_address(vphys_world, 3, 7);
-        let vphys_world_global: u64 = self.process.read(vphys_world_global_ptr);
-        offsets.direct.vphys_world = vphys_world_global;
-
-        let Some(ffa_address) = self
+        offsets.convar.ffa = self
             .process
             .get_convar(offsets.interface.cvar, "mp_teammates_are_enemies")
-        else {
-            utils::warn!("could not get mp_tammates_are_enemies convar offset");
-            return None;
-        };
-        offsets.convar.ffa = ffa_address;
-        let Some(sensitivity_address) = self
-            .process
-            .get_convar(offsets.interface.cvar, "sensitivity")
-        else {
-            utils::warn!("could not get sensitivity convar offset");
-            return None;
-        };
-        offsets.convar.sensitivity = sensitivity_address;
+            .unwrap_or(0);
 
-        let schema = Schema::new(&self.process, offsets.library.schema)?;
         let client = schema.get_library(cs2::CLIENT_LIB)?;
 
         offsets.controller.steam_id = client.get("CBasePlayerController", "m_steamID")?;
@@ -209,8 +165,13 @@ impl CS2 {
         offsets.observer_services.target =
             client.get("CPlayer_ObserverServices", "m_hObserverTarget")?;
 
-        offsets.aim_punch_services.aim_punch_cache =
-            client.get("CCSPlayer_AimPunchServices", "m_unpredictableBaseTick")? - 0x18;
+        offsets.aim_punch_services.aim_punch_cache = client
+            .get_field("CCSPlayer_AimPunchServices", "m_aimPunchAngle")
+            .or_else(|| {
+                client
+                    .get_field("CCSPlayer_AimPunchServices", "m_unpredictableBaseTick")
+                    .map(|offset| offset - 0x18)
+            })?;
 
         offsets.weapon.attribute_manager = client.get("C_EconEntity", "m_AttributeManager")?;
         offsets.weapon.item = client.get("C_AttributeContainer", "m_Item")?;

--- a/cheat/src/cs2/find_offsets.rs
+++ b/cheat/src/cs2/find_offsets.rs
@@ -2,11 +2,7 @@ use std::time::Instant;
 
 use crate::{
     constants::cs2,
-    cs2::{
-        CS2,
-        offsets::Offsets,
-        signatures,
-    },
+    cs2::{CS2, offsets::Offsets, signatures},
 };
 
 impl CS2 {

--- a/cheat/src/cs2/mod.rs
+++ b/cheat/src/cs2/mod.rs
@@ -414,11 +414,16 @@ impl CS2 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{constants::cs2, os::process::Process};
 
     #[test]
     fn setup_against_live_cs2() {
+        if Process::open(cs2::PROCESS_NAME).is_none() {
+            return;
+        }
+
         let mut cs2 = CS2::new();
         cs2.setup();
-        assert!(cs2.is_valid(), "CS2::setup failed — offsets not resolved");
+        assert!(cs2.is_valid(), "CS2::setup failed: offsets not resolved");
     }
 }

--- a/cheat/src/cs2/mod.rs
+++ b/cheat/src/cs2/mod.rs
@@ -41,6 +41,7 @@ mod input;
 pub mod key_codes;
 mod offsets;
 mod schema;
+mod signatures;
 mod target;
 
 #[derive(Debug)]
@@ -352,10 +353,16 @@ impl CS2 {
 
     // convars
     fn get_sensitivity(&self) -> f32 {
+        if self.offsets.convar.sensitivity == 0 {
+            return 1.0;
+        }
         self.process.read(self.offsets.convar.sensitivity + 0x58)
     }
 
     fn is_ffa(&self) -> bool {
+        if self.offsets.convar.ffa == 0 {
+            return false;
+        }
         self.process.read::<u8>(self.offsets.convar.ffa + 0x58) == 1
     }
 
@@ -366,8 +373,10 @@ impl CS2 {
 
     fn current_map(&self) -> String {
         let global_vars: u64 = self.process.read(self.offsets.direct.global_vars);
-        self.process
-            .read_string(self.process.read(global_vars + 0x198))
+        self.process.read_string(
+            self.process
+                .read(global_vars + self.offsets.direct.global_vars_map_name),
+        )
     }
 
     fn distance_scale(&self, distance: f32) -> f32 {
@@ -399,5 +408,17 @@ impl CS2 {
                 *active
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn setup_against_live_cs2() {
+        let mut cs2 = CS2::new();
+        cs2.setup();
+        assert!(cs2.is_valid(), "CS2::setup failed — offsets not resolved");
     }
 }

--- a/cheat/src/cs2/offsets.rs
+++ b/cheat/src/cs2/offsets.rs
@@ -24,6 +24,7 @@ pub struct DirectOffsets {
     pub sdl_window: u64,
     pub planted_c4: u64,
     pub global_vars: u64,
+    pub global_vars_map_name: u64,
     pub vphys_world: u64,
 }
 

--- a/cheat/src/cs2/schema.rs
+++ b/cheat/src/cs2/schema.rs
@@ -7,13 +7,7 @@ pub struct Schema {
 }
 
 impl Schema {
-    pub fn new(process: &Process, schema_module: u64) -> Option<Self> {
-        let schema_system = process.scan(
-            "48 8D 3D ? ? ? ? E8 ? ? ? ? 48 8B BD ? ? ? ? 31 F6 E8 ? ? ? ? E9",
-            schema_module,
-        )?;
-        let schema_system = process.get_relative_address(schema_system, 3, 7);
-
+    pub fn from_system(process: &Process, schema_system: u64) -> Option<Self> {
         let type_scopes_len: i32 = process.read(schema_system + 0x1F0);
         let type_scopes_vec: u64 = process.read(schema_system + 0x1F8);
         let mut scopes = HashMap::new();
@@ -92,6 +86,10 @@ impl ModuleScope {
 
     pub fn get_class(&self, class: &str) -> Option<&Class> {
         self.classes.get(class)
+    }
+
+    pub fn get_field(&self, class: &str, field: &str) -> Option<u64> {
+        self.classes.get(class)?.get(field)
     }
 }
 

--- a/cheat/src/cs2/signatures.json
+++ b/cheat/src/cs2/signatures.json
@@ -1,0 +1,125 @@
+{
+  "signatures": [
+    {
+      "name": "local_player",
+      "module": "libclient.so",
+      "required": true,
+      "variants": [
+        {
+          "pattern": "4C 89 2D ? ? ? ? E8 ? ? ? ? 48 8B 45",
+          "operations": [{ "type": "rip" }]
+        },
+        {
+          "pattern": "4C 89 25 ? ? ? ? E8 ? ? ? ? 48 8B 45",
+          "operations": [{ "type": "rip" }]
+        },
+        {
+          "pattern": "48 83 3D ? ? ? ? 00 0F 95 C0 C3",
+          "operations": [{ "type": "rip", "offset": 3, "len": 8 }]
+        }
+      ]
+    },
+    {
+      "name": "view_matrix",
+      "module": "libclient.so",
+      "required": true,
+      "variants": [
+        {
+          "pattern": "48 8D 05 ? ? ? ? C3 0F 1F 84 00 ? ? ? ? 83 FF",
+          "operations": [{ "type": "rip" }]
+        },
+        {
+          "pattern": "C6 83 ? ? 00 00 01 4C 8D 05",
+          "match_offset": 10,
+          "operations": [{ "type": "rip", "offset": 0, "len": 4 }]
+        }
+      ]
+    },
+    {
+      "name": "global_vars",
+      "module": "libclient.so",
+      "required": true,
+      "variants": [
+        {
+          "pattern": "48 89 35 ? ? ? ? 48 89 46",
+          "operations": [{ "type": "rip" }]
+        },
+        {
+          "pattern": "4C 8D 25 ? ? ? ? 44 8B 5F",
+          "operations": [{ "type": "rip" }]
+        },
+        {
+          "pattern": "48 8D 05 ? ? ? ? 48 8B 00 8B 48 ? E9",
+          "operations": [{ "type": "rip" }]
+        }
+      ]
+    },
+    {
+      "name": "planted_c4",
+      "module": "libclient.so",
+      "required": true,
+      "variants": [
+        {
+          "pattern": "48 8B 05 ? ? ? ? 4C 89 24 D8 49 8B 44 24",
+          "operations": [{ "type": "rip" }]
+        },
+        {
+          "pattern": "48 8D 35 ? ? ? ? 66 0F EF C0 C6 05 ? ? ? ? 01 48 8D 3D",
+          "operations": [{ "type": "rip", "offset": 3, "len": 14 }]
+        }
+      ]
+    },
+    {
+      "name": "entity_system",
+      "module": "libclient.so",
+      "required": true,
+      "variants": [
+        {
+          "pattern": "48 89 3D ? ? ? ? E9 ? ? ? ? 55",
+          "operations": [{ "type": "rip" }, { "type": "read" }]
+        },
+        {
+          "pattern": "4C 89 25 ? ? ? ? 48 89 05 ? ? ? ? 49 8B 5D",
+          "operations": [{ "type": "rip" }, { "type": "read" }]
+        }
+      ]
+    },
+    {
+      "name": "schema_system",
+      "module": "libschemasystem.so",
+      "required": true,
+      "variants": [
+        {
+          "pattern": "48 8D 05 ? ? ? ? 49 89 04 24",
+          "operations": [{ "type": "rip" }]
+        },
+        {
+          "pattern": "48 8D 3D ? ? ? ? E8 ? ? ? ? 48 8B BD ? ? ? ? 31 F6 E8 ? ? ? ? E9",
+          "operations": [{ "type": "rip" }]
+        }
+      ]
+    },
+    {
+      "name": "sensitivity",
+      "module": "libclient.so",
+      "required": false,
+      "variants": [
+        {
+          "pattern": "48 8B 05 ? ? ? ? 48 8B 40 ? E9 ? ? ? ? 48 8B 05 ? ? ? ? 48 8B 40 ? EB ? 0F 1F 00 55 48 89 E5 41 57 66 41 0F 7E DF",
+          "operations": [{ "type": "rip" }]
+        }
+      ]
+    },
+    {
+      "name": "vphys_world",
+      "module": "libclient.so",
+      "required": false,
+      "variants": [
+        {
+          "pattern": "4C 8D 3D ? ? ? ? 49 8B 3F E8 ? ? ? ? 48 89 C2",
+          "operations": [{ "type": "rip" }, { "type": "read" }]
+        }
+      ]
+    }
+  ]
+}

--- a/cheat/src/cs2/signatures.rs
+++ b/cheat/src/cs2/signatures.rs
@@ -1,0 +1,411 @@
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::OnceLock,
+};
+
+use serde::Deserialize;
+
+use crate::{
+    constants::cs2,
+    cs2::{
+        offsets::{DirectOffsets, LibraryOffsets},
+        schema::Schema,
+    },
+    os::process::Process,
+};
+
+const EMBEDDED: &str = include_str!("signatures.json");
+
+static MANIFEST: OnceLock<Manifest> = OnceLock::new();
+
+#[derive(Debug, Deserialize)]
+struct Manifest {
+    signatures: Vec<Signature>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Signature {
+    name: String,
+    module: String,
+    #[serde(default = "default_true")]
+    required: bool,
+    variants: Vec<Variant>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Deserialize)]
+struct Variant {
+    pattern: String,
+    #[serde(default)]
+    match_offset: u64,
+    operations: Vec<Operation>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum Operation {
+    Rip {
+        #[serde(default = "default_rip_offset")]
+        offset: u8,
+        #[serde(default = "default_rip_len")]
+        len: u8,
+    },
+    Add {
+        value: u64,
+    },
+    Slice {
+        start: u8,
+        end: u8,
+    },
+    Read,
+}
+
+fn default_rip_offset() -> u8 {
+    3
+}
+
+fn default_rip_len() -> u8 {
+    7
+}
+
+#[derive(Debug, Default)]
+pub struct Globals {
+    pub direct: DirectOffsets,
+    pub entity_system: u64,
+    pub sensitivity: u64,
+}
+
+pub struct Resolved {
+    pub globals: Globals,
+    pub schema: Schema,
+}
+
+/// Resolve global pointers and schema field offsets. Runs once during CS2::setup.
+pub fn resolve(process: &Process, libraries: &LibraryOffsets) -> Option<Resolved> {
+    let manifest = manifest();
+    let mut modules = ModuleCache::new(process);
+
+    let schema_system = {
+        let sig = manifest.signatures.iter().find(|s| s.name == "schema_system")?;
+        let base = module_base(libraries, &sig.module)?;
+        resolve_validated(process, base, sig, &mut modules, always_valid)?
+    };
+
+    let schema = Schema::from_system(process, schema_system)?;
+    let client = schema.get_library(cs2::CLIENT_LIB)?;
+    let controller_name = client.get("CBasePlayerController", "m_iszPlayerName")?;
+
+    let mut globals = Globals::default();
+
+    for sig in &manifest.signatures {
+        if sig.name == "schema_system" {
+            continue;
+        }
+
+        let base = module_base(libraries, &sig.module)?;
+        let resolved = match sig.name.as_str() {
+            "local_player" => resolve_local_player(
+                process,
+                base,
+                sig,
+                &mut modules,
+                controller_name,
+            )?,
+            "view_matrix" => resolve_validated(
+                process,
+                base,
+                sig,
+                &mut modules,
+                validate_view_matrix,
+            )?,
+            _ if sig.required => {
+                resolve_validated(process, base, sig, &mut modules, always_valid)?
+            }
+            _ => resolve_signature(process, base, sig, &mut modules).unwrap_or(0),
+        };
+
+        match sig.name.as_str() {
+            "local_player" => globals.direct.local_player = resolved,
+            "view_matrix" => globals.direct.view_matrix = resolved,
+            "global_vars" => {
+                globals.direct.global_vars = resolved;
+                globals.direct.global_vars_map_name = detect_map_name_offset(process, resolved);
+            }
+            "planted_c4" => globals.direct.planted_c4 = resolved,
+            "entity_system" => globals.entity_system = resolved,
+            "vphys_world" => globals.direct.vphys_world = resolved,
+            "sensitivity" => globals.sensitivity = resolved,
+            _ => {}
+        }
+    }
+
+    Some(Resolved { globals, schema })
+}
+
+fn resolve_local_player(
+    process: &Process,
+    module_base: u64,
+    sig: &Signature,
+    modules: &mut ModuleCache,
+    name_offset: u64,
+) -> Option<u64> {
+    for (i, variant) in sig.variants.iter().enumerate() {
+        let Some(match_addr) = modules.scan(&variant.pattern, module_base) else {
+            continue;
+        };
+        let instruction = match_addr.wrapping_add(variant.match_offset);
+        let Some(resolved) = apply_ops(process, instruction, &variant.operations) else {
+            continue;
+        };
+        if !validate_local_player(process, resolved, name_offset) {
+            continue;
+        }
+        utils::debug!("signature {}: variant {i} matched", sig.name);
+        return Some(resolved);
+    }
+    utils::warn!("signature {}: all patterns failed", sig.name);
+    None
+}
+
+fn resolve_validated(
+    process: &Process,
+    module_base: u64,
+    sig: &Signature,
+    modules: &mut ModuleCache,
+    validate: fn(&Process, u64) -> bool,
+) -> Option<u64> {
+    for (i, variant) in sig.variants.iter().enumerate() {
+        let Some(match_addr) = modules.scan(&variant.pattern, module_base) else {
+            continue;
+        };
+        let instruction = match_addr.wrapping_add(variant.match_offset);
+        let Some(resolved) = apply_ops(process, instruction, &variant.operations) else {
+            continue;
+        };
+        if !validate(process, resolved) {
+            continue;
+        }
+        utils::debug!("signature {}: variant {i} matched", sig.name);
+        return Some(resolved);
+    }
+    utils::warn!("signature {}: all patterns failed", sig.name);
+    None
+}
+
+fn resolve_signature(
+    process: &Process,
+    module_base: u64,
+    sig: &Signature,
+    modules: &mut ModuleCache,
+) -> Option<u64> {
+    for (i, variant) in sig.variants.iter().enumerate() {
+        let Some(match_addr) = modules.scan(&variant.pattern, module_base) else {
+            continue;
+        };
+        let instruction = match_addr.wrapping_add(variant.match_offset);
+        if let Some(resolved) = apply_ops(process, instruction, &variant.operations) {
+            utils::debug!("signature {}: variant {i} matched", sig.name);
+            return Some(resolved);
+        }
+    }
+
+    if sig.required {
+        utils::warn!("signature {}: all patterns failed", sig.name);
+    }
+    None
+}
+
+fn apply_ops(process: &Process, mut addr: u64, ops: &[Operation]) -> Option<u64> {
+    for op in ops {
+        addr = match op {
+            Operation::Rip { offset, len } => {
+                process.get_relative_address(addr, *offset as u64, *len as u64)
+            }
+            Operation::Add { value } => addr.wrapping_add(*value),
+            Operation::Slice { start, end } => {
+                let bytes = process.read_bytes(addr + *start as u64, (*end - *start) as u64);
+                let mut value = 0u64;
+                for (i, byte) in bytes.iter().enumerate() {
+                    value |= (*byte as u64) << (i * 8);
+                }
+                value
+            }
+            Operation::Read => process.read(addr),
+        };
+    }
+    Some(addr)
+}
+
+fn always_valid(_: &Process, _: u64) -> bool {
+    true
+}
+
+fn validate_view_matrix(process: &Process, addr: u64) -> bool {
+    let value: f32 = process.read(addr);
+    value.is_finite() && value.abs() < 100.0
+}
+
+fn validate_local_player(process: &Process, global_addr: u64, name_offset: u64) -> bool {
+    let controller: u64 = process.read(global_addr);
+    if controller == 0 {
+        return true;
+    }
+    let name_ptr: u64 = process.read(controller + name_offset);
+    if name_ptr == 0 {
+        return true;
+    }
+    let name = process.read_string_uncached(name_ptr);
+    if name.is_empty() {
+        return true;
+    }
+    name.len() < 64 && name.chars().all(|c| c.is_ascii_graphic() || c == ' ')
+}
+
+fn detect_map_name_offset(process: &Process, global_vars_global: u64) -> u64 {
+    const CANDIDATES: [u64; 2] = [0x1C8, 0x198];
+    let global_vars: u64 = process.read(global_vars_global);
+    if global_vars == 0 {
+        return CANDIDATES[0];
+    }
+
+    for offset in CANDIDATES {
+        let name_ptr: u64 = process.read(global_vars + offset);
+        if name_ptr == 0 {
+            continue;
+        }
+        let name = process.read_string_uncached(name_ptr);
+        if name.starts_with("de_") || name.starts_with("cs_") || name.starts_with("ar_") {
+            return offset;
+        }
+    }
+    CANDIDATES[0]
+}
+
+fn module_base(libraries: &LibraryOffsets, module: &str) -> Option<u64> {
+    match module {
+        cs2::CLIENT_LIB => Some(libraries.client),
+        cs2::SCHEMA_LIB => Some(libraries.schema),
+        _ => None,
+    }
+}
+
+fn manifest() -> &'static Manifest {
+    MANIFEST.get_or_init(|| {
+        let mut manifest: Manifest =
+            serde_json::from_str(EMBEDDED).expect("embedded signatures.json");
+
+        if let Ok(path) = override_path() {
+            if let Ok(content) = std::fs::read_to_string(path) {
+                if let Ok(overlay) = serde_json::from_str::<Manifest>(&content) {
+                    merge_manifest(&mut manifest, overlay);
+                }
+            }
+        }
+
+        manifest
+    })
+}
+
+fn override_path() -> Result<PathBuf, std::env::VarError> {
+    let config = std::env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+        format!("{home}/.config")
+    });
+    Ok(PathBuf::from(config).join("deadlocked/signatures.json"))
+}
+
+fn merge_manifest(base: &mut Manifest, overlay: Manifest) {
+    for overlay_sig in overlay.signatures {
+        let Some(local) = base.signatures.iter_mut().find(|s| s.name == overlay_sig.name)
+        else {
+            base.signatures.push(overlay_sig);
+            continue;
+        };
+        for variant in overlay_sig.variants.into_iter().rev() {
+            local.variants.insert(0, variant);
+        }
+    }
+}
+
+struct ModuleCache<'a> {
+    process: &'a Process,
+    modules: HashMap<u64, Vec<u8>>,
+}
+
+impl<'a> ModuleCache<'a> {
+    fn new(process: &'a Process) -> Self {
+        Self {
+            process,
+            modules: HashMap::new(),
+        }
+    }
+
+    fn scan(&mut self, pattern: &str, base_address: u64) -> Option<u64> {
+        let module = self
+            .modules
+            .entry(base_address)
+            .or_insert_with(|| self.process.dump_module(base_address));
+
+        let (bytes, mask) = parse_pattern(pattern)?;
+        if module.len() < bytes.len() {
+            return None;
+        }
+
+        let scan = if bytes.len() <= 32 && is_x86_feature_detected!("avx2") {
+            crate::os::process::scan_simd
+        } else {
+            crate::os::process::scan_normal
+        };
+
+        scan(&bytes, &mask, module).map(|offset| base_address + offset)
+    }
+}
+
+fn parse_pattern(pattern: &str) -> Option<(Vec<u8>, Vec<u8>)> {
+    let mut bytes = Vec::new();
+    let mut mask = Vec::new();
+
+    for token in pattern.split_whitespace() {
+        if token == "?" || token == "??" {
+            bytes.push(0x00);
+            mask.push(0x00);
+        } else if token.len() == 2 {
+            bytes.push(u8::from_str_radix(token, 16).ok()?);
+            mask.push(0xFF);
+        }
+    }
+
+    if bytes.is_empty() { None } else { Some((bytes, mask)) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{constants::cs2, cs2::offsets::LibraryOffsets, os::process::Process};
+
+    #[test]
+    fn resolve_against_live_cs2() {
+        let Some(process) = Process::open(cs2::PROCESS_NAME) else {
+            return;
+        };
+
+        let libraries = LibraryOffsets {
+            client: process.module_base_address(cs2::CLIENT_LIB).unwrap(),
+            engine: process.module_base_address(cs2::ENGINE_LIB).unwrap(),
+            tier0: process.module_base_address(cs2::TIER0_LIB).unwrap(),
+            input: process.module_base_address(cs2::INPUT_LIB).unwrap(),
+            sdl: process.module_base_address(cs2::SDL_LIB).unwrap(),
+            schema: process.module_base_address(cs2::SCHEMA_LIB).unwrap(),
+        };
+
+        let resolved = resolve(&process, &libraries).expect("offset resolution failed");
+        assert_ne!(resolved.globals.direct.local_player, 0);
+        assert_ne!(resolved.globals.direct.view_matrix, 0);
+        assert_ne!(resolved.globals.entity_system, 0);
+        assert!(resolved.schema.get_library(cs2::CLIENT_LIB).is_some());
+    }
+}

--- a/cheat/src/cs2/signatures.rs
+++ b/cheat/src/cs2/signatures.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::HashMap,
-    path::PathBuf,
-    sync::OnceLock,
-};
+use std::{collections::HashMap, path::PathBuf, sync::OnceLock};
 
 use serde::Deserialize;
 
@@ -54,13 +50,6 @@ enum Operation {
         #[serde(default = "default_rip_len")]
         len: u8,
     },
-    Add {
-        value: u64,
-    },
-    Slice {
-        start: u8,
-        end: u8,
-    },
     Read,
 }
 
@@ -90,7 +79,10 @@ pub fn resolve(process: &Process, libraries: &LibraryOffsets) -> Option<Resolved
     let mut modules = ModuleCache::new(process);
 
     let schema_system = {
-        let sig = manifest.signatures.iter().find(|s| s.name == "schema_system")?;
+        let sig = manifest
+            .signatures
+            .iter()
+            .find(|s| s.name == "schema_system")?;
         let base = module_base(libraries, &sig.module)?;
         resolve_validated(process, base, sig, &mut modules, always_valid)?
     };
@@ -108,23 +100,13 @@ pub fn resolve(process: &Process, libraries: &LibraryOffsets) -> Option<Resolved
 
         let base = module_base(libraries, &sig.module)?;
         let resolved = match sig.name.as_str() {
-            "local_player" => resolve_local_player(
-                process,
-                base,
-                sig,
-                &mut modules,
-                controller_name,
-            )?,
-            "view_matrix" => resolve_validated(
-                process,
-                base,
-                sig,
-                &mut modules,
-                validate_view_matrix,
-            )?,
-            _ if sig.required => {
-                resolve_validated(process, base, sig, &mut modules, always_valid)?
+            "local_player" => {
+                resolve_local_player(process, base, sig, &mut modules, controller_name)?
             }
+            "view_matrix" => {
+                resolve_validated(process, base, sig, &mut modules, validate_view_matrix)?
+            }
+            _ if sig.required => resolve_validated(process, base, sig, &mut modules, always_valid)?,
             _ => resolve_signature(process, base, sig, &mut modules).unwrap_or(0),
         };
 
@@ -225,15 +207,6 @@ fn apply_ops(process: &Process, mut addr: u64, ops: &[Operation]) -> Option<u64>
             Operation::Rip { offset, len } => {
                 process.get_relative_address(addr, *offset as u64, *len as u64)
             }
-            Operation::Add { value } => addr.wrapping_add(*value),
-            Operation::Slice { start, end } => {
-                let bytes = process.read_bytes(addr + *start as u64, (*end - *start) as u64);
-                let mut value = 0u64;
-                for (i, byte) in bytes.iter().enumerate() {
-                    value |= (*byte as u64) << (i * 8);
-                }
-                value
-            }
             Operation::Read => process.read(addr),
         };
     }
@@ -298,29 +271,30 @@ fn manifest() -> &'static Manifest {
         let mut manifest: Manifest =
             serde_json::from_str(EMBEDDED).expect("embedded signatures.json");
 
-        if let Ok(path) = override_path() {
-            if let Ok(content) = std::fs::read_to_string(path) {
-                if let Ok(overlay) = serde_json::from_str::<Manifest>(&content) {
-                    merge_manifest(&mut manifest, overlay);
-                }
-            }
+        if let Ok(content) = std::fs::read_to_string(override_path())
+            && let Ok(overlay) = serde_json::from_str::<Manifest>(&content)
+        {
+            merge_manifest(&mut manifest, overlay);
         }
 
         manifest
     })
 }
 
-fn override_path() -> Result<PathBuf, std::env::VarError> {
+fn override_path() -> PathBuf {
     let config = std::env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
         format!("{home}/.config")
     });
-    Ok(PathBuf::from(config).join("deadlocked/signatures.json"))
+    PathBuf::from(config).join("deadlocked/signatures.json")
 }
 
 fn merge_manifest(base: &mut Manifest, overlay: Manifest) {
     for overlay_sig in overlay.signatures {
-        let Some(local) = base.signatures.iter_mut().find(|s| s.name == overlay_sig.name)
+        let Some(local) = base
+            .signatures
+            .iter_mut()
+            .find(|s| s.name == overlay_sig.name)
         else {
             base.signatures.push(overlay_sig);
             continue;
@@ -379,7 +353,11 @@ fn parse_pattern(pattern: &str) -> Option<(Vec<u8>, Vec<u8>)> {
         }
     }
 
-    if bytes.is_empty() { None } else { Some((bytes, mask)) }
+    if bytes.is_empty() {
+        None
+    } else {
+        Some((bytes, mask))
+    }
 }
 
 #[cfg(test)]

--- a/cheat/src/os/process.rs
+++ b/cheat/src/os/process.rs
@@ -352,16 +352,16 @@ impl Process {
             return None;
         }
 
-        const LAYOUTS: [(u64, u64, u64); 3] = [
-            (0x40, 0xA0, 2),
-            (0x48, 0xA0, 4),
-            (0x48, 160, 4),
-        ];
+        const LAYOUTS: [(u64, u64, u64); 3] = [(0x40, 0xA0, 2), (0x48, 0xA0, 4), (0x48, 160, 4)];
 
         for (list_off, count_off, count_size) in LAYOUTS {
-            if let Some(found) =
-                self.find_convar(convar_interface, convar_name, list_off, count_off, count_size)
-            {
+            if let Some(found) = self.find_convar(
+                convar_interface,
+                convar_name,
+                list_off,
+                count_off,
+                count_size,
+            ) {
                 return Some(found);
             }
         }

--- a/cheat/src/os/process.rs
+++ b/cheat/src/os/process.rs
@@ -252,50 +252,6 @@ impl Process {
         self.read_bytes(address, module_size)
     }
 
-    pub fn scan(&self, pattern: &str, base_address: u64) -> Option<u64> {
-        let mut bytes = Vec::with_capacity(8);
-        let mut mask = Vec::with_capacity(8);
-
-        for token in pattern.split_whitespace() {
-            if token == "?" || token == "??" {
-                bytes.push(0x00);
-                mask.push(0x00);
-            } else if token.len() == 2 {
-                match u8::from_str_radix(token, 16) {
-                    Ok(b) => {
-                        bytes.push(b);
-                        mask.push(0xFF);
-                    }
-                    Err(_) => {
-                        utils::warn!("unrecognized pattern token \"{token}\" in pattern {pattern}");
-                    }
-                }
-            } else {
-                utils::warn!("unrecognized pattern token \"{token}\" in pattern {pattern}");
-            }
-        }
-
-        let module = self.dump_module(base_address);
-        if module.len() < 500 {
-            return None;
-        }
-
-        let scan_func = if bytes.len() <= 32 && is_x86_feature_detected!("avx2") {
-            scan_simd
-        } else {
-            scan_normal
-        };
-
-        if let Some(address) =
-            scan_func(&bytes, &mask, &module).map(|address| base_address + address)
-        {
-            return Some(address);
-        }
-
-        utils::info!("pattern {pattern} not found, might be outdated");
-        None
-    }
-
     pub fn get_relative_address(
         &self,
         instruction: u64,
@@ -396,20 +352,62 @@ impl Process {
             return None;
         }
 
-        let objects = self.read::<u64>(convar_interface + 0x48);
-        for i in 0..self.read::<u32>(convar_interface + 160) as u64 {
-            let object = self.read(objects + i * 16);
+        const LAYOUTS: [(u64, u64, u64); 3] = [
+            (0x40, 0xA0, 2),
+            (0x48, 0xA0, 4),
+            (0x48, 160, 4),
+        ];
+
+        for (list_off, count_off, count_size) in LAYOUTS {
+            if let Some(found) =
+                self.find_convar(convar_interface, convar_name, list_off, count_off, count_size)
+            {
+                return Some(found);
+            }
+        }
+
+        utils::debug!("did not find convar {convar_name}");
+        None
+    }
+
+    fn find_convar(
+        &self,
+        convar_interface: u64,
+        convar_name: &str,
+        list_off: u64,
+        count_off: u64,
+        count_size: u64,
+    ) -> Option<u64> {
+        let list = self.read::<u64>(convar_interface + list_off);
+        if list == 0 {
+            return None;
+        }
+
+        let count = match count_size {
+            2 => self.read::<u16>(convar_interface + count_off) as u64,
+            _ => self.read::<u32>(convar_interface + count_off) as u64,
+        };
+        if count == 0 || count > 20_000 {
+            return None;
+        }
+
+        for i in 0..count {
+            let object = self.read(list + i * 16);
             if object == 0 {
                 break;
             }
 
             let name_address = self.read(object);
+            if name_address == 0 {
+                continue;
+            }
+
             let name = self.read_string_uncached(name_address);
             if name == convar_name {
                 return Some(object);
             }
         }
-        utils::warn!("did not find convar {convar_name}");
+
         None
     }
 
@@ -468,7 +466,7 @@ impl Process {
     }
 }
 
-fn scan_normal(bytes: &[u8], mask: &[u8], module: &[u8]) -> Option<u64> {
+pub(crate) fn scan_normal(bytes: &[u8], mask: &[u8], module: &[u8]) -> Option<u64> {
     let pattern_length = bytes.len();
     let stop_index = module.len() - pattern_length;
     'outer: for i in 0..stop_index {
@@ -482,7 +480,7 @@ fn scan_normal(bytes: &[u8], mask: &[u8], module: &[u8]) -> Option<u64> {
     None
 }
 
-fn scan_simd(bytes: &[u8], mask: &[u8], module: &[u8]) -> Option<u64> {
+pub(crate) fn scan_simd(bytes: &[u8], mask: &[u8], module: &[u8]) -> Option<u64> {
     use std::arch::x86_64::{
         __m256i, _mm256_and_si256, _mm256_loadu_si256, _mm256_testz_si256, _mm256_xor_si256,
     };

--- a/cheat/src/ui/gui/hud.rs
+++ b/cheat/src/ui/gui/hud.rs
@@ -1,7 +1,8 @@
 use egui::{DragValue, Ui};
 
 use crate::ui::{
-    app::App, gui::helpers::{checkbox, collapsing_open, color_picker, combo_box, drag, scroll},
+    app::App,
+    gui::helpers::{checkbox, collapsing_open, color_picker, combo_box, drag, scroll},
 };
 
 impl App {


### PR DESCRIPTION
In short: remove the need for developer to constantly patch the offsets on game update, and no more issues like "stopped working after new update"

Move CS2 globals to signature-based resolution.

Hardcoded scans for local player, view matrix, global vars, planted C4, schema system, etc. now live in `signatures.json` with fallback patterns. They are still resolved once during `CS2::setup()`.

Also:
- keep entity list on `GameResourceServiceClient`
- support `~/.config/deadlocked/signatures.json` overrides
- make convar lookup tolerate newer layouts
- prefer `m_aimPunchAngle`, fallback to old aim-punch offset

Tested:
- `cargo fmt --check`
- `cargo clippy -p deadlocked --all-targets -- -D warnings`
- `cargo test -p deadlocked`