### PR TITLE
fix: avoid requiring reboot for uinput permissions

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,32 +1,32 @@
 #!/usr/bin/env bash
-
 UDEV_RULE_FILE="/etc/udev/rules.d/99-uinput.rules"
 UINPUT_GROUP="uinput"
 CURRENT_USER=$(whoami)
-
 git config core.hooksPath .hooks
 
-echo 'KERNEL=="uinput", MODE="0660", GROUP="uinput"' | sudo tee "$UDEV_RULE_FILE" > /dev/null
+sudo modprobe uinput
+
+echo 'KERNEL=="uinput", MODE="0660", GROUP="uinput", TAG+="uaccess"' | sudo tee "$UDEV_RULE_FILE" > /dev/null
 echo "created udev file: $UDEV_RULE_FILE"
 
 if ! getent group "$UINPUT_GROUP" > /dev/null; then
     sudo groupadd "$UINPUT_GROUP"
     echo "created group $UINPUT_GROUP"
 fi
-
 sudo usermod -aG "$UINPUT_GROUP" "$CURRENT_USER"
 echo "added user $CURRENT_USER to group $UINPUT_GROUP"
 
 sudo udevadm control --reload-rules
-sudo udevadm trigger
+sudo udevadm trigger --action=add --sysname-match=uinput
+sudo udevadm settle
 echo "reloaded udev rules"
+
+echo "uinput" | sudo tee /etc/modules-load.d/uinput.conf > /dev/null
 
 if [ "$XDG_CURRENT_DESKTOP" = "Hyprland" ]; then
     echo "detected Hyprland as window manager"
-
     RULE="windowrule = no_blur 1, match:title ^(deadlocked_overlay)$"
     CONF_FILE="$HOME/.config/hypr/hyprland.conf"
-
     if grep -Fxq "$RULE" "$CONF_FILE"; then
         echo "deadlocked_overlay windowrule has already been added, skipping"
     else


### PR DESCRIPTION
previously, after running the setup script, a full reboot was required
before the client could actually open `/dev/uinput`. this was because:

1. group membership changes from `usermod -aG uinput $USER` aren't
   picked up by the current login session, only new sessions see it.
2. if the `uinput` kernel module wasn't already loaded, `/dev/uinput`
   didn't exist yet, so the udev rule had nothing to apply to until
   next boot.

## fix
- `modprobe uinput` up front so the device node exists immediately.
- add `TAG+="uaccess"` to the udev rule, which tells `systemd-logind`
  to grant the current active session an ACL on the device the moment
  it appears. this bypasses the group-membership caching problem
  entirely, so no logout/reboot is needed.
- `udevadm trigger --action=add --sysname-match=uinput` + `udevadm settle`
  to apply the new rule to the already-existing device deterministically.
- add `/etc/modules-load.d/uinput.conf` so the module keeps autoloading
  on future boots.

## note
the group/`usermod` logic was kept as a fallback for anything that checks group membership specifically.