### PR TITLE
Hyprland now uses .lua config files!

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
+
 UDEV_RULE_FILE="/etc/udev/rules.d/99-uinput.rules"
 UINPUT_GROUP="uinput"
 CURRENT_USER=$(whoami)
+
 git config core.hooksPath .hooks
 
 sudo modprobe uinput
@@ -10,9 +12,10 @@ echo 'KERNEL=="uinput", MODE="0660", GROUP="uinput", TAG+="uaccess"' | sudo tee 
 echo "created udev file: $UDEV_RULE_FILE"
 
 if ! getent group "$UINPUT_GROUP" > /dev/null; then
-    sudo groupadd "$UINPUT_GROUP"
-    echo "created group $UINPUT_GROUP"
+  sudo groupadd "$UINPUT_GROUP"
+  echo "created group $UINPUT_GROUP"
 fi
+
 sudo usermod -aG "$UINPUT_GROUP" "$CURRENT_USER"
 echo "added user $CURRENT_USER to group $UINPUT_GROUP"
 
@@ -24,13 +27,23 @@ echo "reloaded udev rules"
 echo "uinput" | sudo tee /etc/modules-load.d/uinput.conf > /dev/null
 
 if [ "$XDG_CURRENT_DESKTOP" = "Hyprland" ]; then
-    echo "detected Hyprland as window manager"
-    RULE="windowrule = no_blur 1, match:title ^(deadlocked_overlay)$"
-    CONF_FILE="$HOME/.config/hypr/hyprland.conf"
-    if grep -Fxq "$RULE" "$CONF_FILE"; then
-        echo "deadlocked_overlay windowrule has already been added, skipping"
-    else
-        echo "$RULE" >> "$CONF_FILE"
-        echo "added windowrule to Hyprland"
-    fi
+  echo "detected Hyprland as window manager"
+
+  RULE='
+-- deadlocked_overlay no_blur windowrule
+hl.window_rule({
+    match = {
+        title = "^(deadlocked_overlay)$",
+    },
+    no_blur = true,
+})'
+
+  LUA_FILE="$HOME/.config/hypr/hyprland.lua"
+
+  if grep -Fq 'title = "^(deadlocked_overlay)$"' "$LUA_FILE"; then
+    echo "deadlocked_overlay no_blur windowrule has already been added, skipping"
+  else
+    echo "$RULE" >> "$LUA_FILE"
+    echo "added no_blur windowrule to Hyprland"
+  fi
 fi


### PR DESCRIPTION
fix the `setup.sh` to add no_blur windowrules to the new `hyprland.lua` file rather than the old `hyprland.conf` file, also changed the syntax to the new lua syntax

it works, i checked it quite a few times

creates a output like this:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0ef35ea2-35a5-4a89-94ad-b77375cbd021" />
