### PR TITLE
Complete Hyprland Lua Fix

### DIFF
--- a/compatibility.md
+++ b/compatibility.md
@@ -1,8 +1,6 @@
-# Compatibility
+# Operating Systems
 
-## Operating Systems
-
-### NixOS
+## NixOS
 
 Add `"input"` to your user's `extraGroups` in `configuration.nix`:
 
@@ -31,17 +29,21 @@ cargo run --release
 
 Everything is configured in `flake.nix` and `nix/shell.nix`.
 
-### Fedora Atomic
+## Fedora Atomic
 
 ```bash
 grep -E '^input:' /usr/lib/group | sudo tee -a /etc/group && sudo usermod -aG input $USER
-# Restart your machine (required)
+```
+#### Restart your machine (required)
+
+```bash
 git clone --recursive https://github.com/avitran0/deadlocked
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
-## Window Managers:
 
-### Hyprland
+# Window Managers:
+
+## Hyprland
 
 The setup script automatically adds the required `no_blur` window rule for users running the Lua configuration format.
 

--- a/compatibility.md
+++ b/compatibility.md
@@ -41,13 +41,15 @@ git clone --recursive https://github.com/avitran0/deadlocked
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
+<br>
+
 # Window Managers:
 
 ## Hyprland
 
 The setup script automatically adds the required `no_blur` window rule for users running the Lua configuration format.
 
-If you're using the legacy `.conf` configuration, add the following rule manually to `hyprland.conf`:
+If you're using the legacy `.conf` configuration (_Deprecated as of Hyprland 0.55, but still supported_) , add the following rule manually to `hyprland.conf`:
 
 ```conf
 windowrule = no_blur 1, match:title ^(deadlocked_overlay)$

--- a/compatibility.md
+++ b/compatibility.md
@@ -61,7 +61,7 @@ hl.window_rule({
 
 ```
 
-If you're using the legacy `.conf` configuration (_Deprecated as of Hyprland 0.55, but still supported_) , add the following rule manually to `hyprland.conf`:
+If you're using the legacy .conf configuration (_Deprecated as of Hyprland 0.55, but still supported_) , add the following rule manually to `hyprland.conf`:
 
 ```conf
 windowrule = no_blur 1, match:title ^(deadlocked_overlay)$

--- a/compatibility.md
+++ b/compatibility.md
@@ -51,6 +51,16 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 The setup script automatically adds the required `no_blur` window rule for users running the Lua configuration format.
 
+```lua
+hl.window_rule({
+	match = {
+		title = "^(deadlocked_overlay)$",
+	},
+	no_blur = true,
+})
+
+```
+
 If you're using the legacy `.conf` configuration (_Deprecated as of Hyprland 0.55, but still supported_) , add the following rule manually to `hyprland.conf`:
 
 ```conf

--- a/compatibility.md
+++ b/compatibility.md
@@ -66,3 +66,4 @@ If you're using the legacy .conf configuration (_Deprecated as of Hyprland 0.55,
 ```conf
 windowrule = no_blur 1, match:title ^(deadlocked_overlay)$
 ```
+Hyprland has poor X11 support for the techniques this cheat uses, not much i can do about that. May require additional tweaks.

--- a/compatibility.md
+++ b/compatibility.md
@@ -1,6 +1,8 @@
-# OS-Specific setup
+# Compatibility
 
-## NixOS
+## Operating Systems
+
+### NixOS
 
 Add `"input"` to your user's `extraGroups` in `configuration.nix`:
 
@@ -29,11 +31,22 @@ cargo run --release
 
 Everything is configured in `flake.nix` and `nix/shell.nix`.
 
-## Fedora Atomic
+### Fedora Atomic
 
 ```bash
 grep -E '^input:' /usr/lib/group | sudo tee -a /etc/group && sudo usermod -aG input $USER
 # Restart your machine (required)
 git clone --recursive https://github.com/avitran0/deadlocked
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+## Window Managers:
+
+### Hyprland
+
+The setup script automatically adds the required `no_blur` window rule for users running the Lua configuration format.
+
+If you're using the legacy `.conf` configuration, add the following rule manually to `hyprland.conf`:
+
+```conf
+windowrule = no_blur 1, match:title ^(deadlocked_overlay)$
 ```

--- a/compatibility.md
+++ b/compatibility.md
@@ -32,9 +32,11 @@ Everything is configured in `flake.nix` and `nix/shell.nix`.
 ## Fedora Atomic
 
 ```bash
-grep -E '^input:' /usr/lib/group | sudo tee -a /etc/group && sudo usermod -aG input $USER
+grep -E '^input:' /usr/lib/group | sudo tee -a /etc/group
+sudo usermod -aG input "$USER"
 ```
-#### Restart your machine (required)
+
+> **Restart your machine (required)**
 
 ```bash
 git clone --recursive https://github.com/avitran0/deadlocked

--- a/compatibility.md
+++ b/compatibility.md
@@ -29,6 +29,8 @@ cargo run --release
 
 Everything is configured in `flake.nix` and `nix/shell.nix`.
 
+<br>
+
 ## Fedora Atomic
 
 ```bash
@@ -44,8 +46,9 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
 <br>
+<br>
 
-# Window Managers:
+# Window Managers
 
 ## Hyprland
 

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,9 @@
+<div align="center">
+
 # deadlocked
 
-[![Matrix Invite](https://img.shields.io/matrix/open-source-cs2-hacking%3Amatrix.org?style=for-the-badge&logo=matrix&label=Matrix)](https://matrix.to/#/%23open-source-cs2-hacking:matrix.org)
-
-[![Discord Invite](https://img.shields.io/discord/1333541580249890949?style=for-the-badge&logo=discord&logoColor=white&label=Discord)](https://discord.gg/eXjG4Ar9Sx)
+[![Matrix Invite](https://img.shields.io/matrix/open-source-cs2-hacking%3Amatrix.org?style=for-the-badge\&logo=matrix\&label=Matrix)](https://matrix.to/#/%23open-source-cs2-hacking:matrix.org)
+[![Discord Invite](https://img.shields.io/discord/1333541580249890949?style=for-the-badge\&logo=discord\&logoColor=white\&label=Discord)](https://discord.gg/eXjG4Ar9Sx)
 
 [![Casual Maintenance Intended](https://casuallymaintained.tech/badge.svg)](https://casuallymaintained.tech/)
 
@@ -10,6 +11,8 @@ simple cs2 aimbot and esp, for linux only.
 
 Releases are tagged `v<version>` matching the version in `Cargo.toml` (e.g. `v1.0.0`).
 The built-in update checker compares against the latest release tag and will prompt when a newer version is available.
+
+</div>
 
 ## Quick Start
 

--- a/readme.md
+++ b/readme.md
@@ -13,8 +13,12 @@ The built-in update checker compares against the latest release tag and will pro
 
 ## Quick Start
 
-Download the [latest release](https://github.com/avitran0/deadlocked/releases).
-Each release contains the `deadlocked` binary and `setup.sh`.
+> [!NOTE]
+> Running NixOS, Fedora Atomic, Hyprland (Legacy .conf config)?
+> 
+> See the [Compatibility Guide](compatibility.md).
+
+Download the [latest release](https://github.com/avitran0/deadlocked/releases). Each release contains the `deadlocked` binary and `setup.sh`.
 
 **Setup (one-time only):**
 
@@ -26,7 +30,7 @@ Each release contains the `deadlocked` binary and `setup.sh`.
 This creates a `uinput` group, adds your user to it, and installs a udev rule.
 You only need to do this once, even when updating to newer versions.
 
-## Running
+**Run:**
 
 ```bash
 ./deadlocked
@@ -34,7 +38,6 @@ You only need to do this once, even when updating to newer versions.
 
 The binary will refuse to start if setup hasn't been completed.
 Also make sure the `uinput` kernel module is loaded.
-Running NixOS or Fedora Atomic? See [OS-Specific Setup](os-setup.md).
 
 ## Build from Source
 
@@ -45,7 +48,7 @@ cd deadlocked
 cargo run --release
 ```
 
-**Run:**
+## Running
 
 ```bash
 ./run.sh

--- a/readme.md
+++ b/readme.md
@@ -7,12 +7,18 @@
 
 [![Casual Maintenance Intended](https://casuallymaintained.tech/badge.svg)](https://casuallymaintained.tech/)
 
+<br>
+
 simple cs2 aimbot and esp, for linux only.
+
+<br>
 
 Releases are tagged `v<version>` matching the version in `Cargo.toml` (e.g. `v1.0.0`).
 The built-in update checker compares against the latest release tag and will prompt when a newer version is available.
 
 </div>
+
+<br>
 
 ## Quick Start
 
@@ -42,6 +48,8 @@ You only need to do this once, even when updating to newer versions.
 The binary will refuse to start if setup hasn't been completed.
 Also make sure the `uinput` kernel module is loaded.
 
+<br>
+
 ## Build from Source
 
 ```bash
@@ -51,11 +59,15 @@ cd deadlocked
 cargo run --release
 ```
 
+<br>
+
 ## Running
 
 ```bash
 ./run.sh
 ```
+
+<br>
 
 ## Features
 
@@ -119,6 +131,8 @@ cargo run --release
 - FOV changer
 - No smoke
 - Smoke color change
+
+<br>
 
 ## FAQ
 

--- a/readme.md
+++ b/readme.md
@@ -163,7 +163,7 @@ Configs are saved in `$XDG_CONFIG_HOME` with fallback to `$HOME/.config`. Otherw
 * i3
 * OpenBox
 * XFCE
-* Hyprland (tweaks may be needed; no guarantees)
+* Hyprland (tweaks may be needed, no guarantees; see [compatibility,md](compatibility.md/#hyprland))
 
 </details>
 

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ The built-in update checker compares against the latest release tag and will pro
 > [!NOTE]
 > Running NixOS, Fedora Atomic, Hyprland (Legacy .conf config)?
 > 
-> See the [Compatibility Guide](compatibility.md).
+> See the [compatibility,md](compatibility.md).
 
 Download the [latest release](https://github.com/avitran0/deadlocked/releases). Each release contains the `deadlocked` binary and `setup.sh`.
 

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ cd deadlocked
 cargo run --release
 ```
 
-## Running
+**Run:**
 
 ```bash
 ./run.sh

--- a/readme.md
+++ b/readme.md
@@ -116,53 +116,91 @@ cargo run --release
 
 ## FAQ
 
-### Where are my configs saved?
+<details>
+<summary>Where are my configs saved?</summary>
 
 Configs are saved in `$XDG_CONFIG_HOME` with fallback to `$HOME/.config`. Otherwise they're saved alongside the executable.
 
-### Which desktop environments and window managers are supported?
+</details>
+
+<br>
+
+<details>
+<summary>Which desktop environments and window managers are supported?</summary>
 
 **Best support:**
 
-- GNOME (Mutter)
-- KDE (KWin)
+* GNOME (Mutter)
+* KDE (KWin)
 
 **Good support:**
 
-- SwayWM
-- Weston
+* SwayWM
+* Weston
 
 **Fair support:**
 
-- i3
-- OpenBox
-- XFCE
-- Hyprland (tweaks may be needed; no guarantees)
+* i3
+* OpenBox
+* XFCE
+* Hyprland (tweaks may be needed; no guarantees)
 
-### I'm using Hyprland and something doesn't work
+</details>
 
-Hyprland has poor X11 support for the techniques this cheat uses, not much i can do about that.
+<br>
+
+<details>
+<summary>I'm using Hyprland and something doesn't work</summary>
+
+Hyprland has poor X11 support for the techniques this cheat uses, not much I can do about that.
 Try another WM if possible.
 
-### I'm using Gamescope and the overlay is too small
+</details>
+
+<br>
+
+<details>
+<summary>I'm using Gamescope and the overlay is too small</summary>
 
 The game still thinks it's running in 16:9 resolution, so the cheat gets the wrong window resolution.
 Try running the game without Gamescope.
 
-### My screen/overlay is black
+</details>
+
+<br>
+
+<details>
+<summary>My screen/overlay is black</summary>
 
 Your compositor or window manager doesn't support transparency, or it's not enabled.
 
-On KDE, go into the `Display and Monitor` settings, then `Compositor`, and tick `Enable compositor on startup`.
+On KDE, go into **Display and Monitor** settings, then **Compositor**, and tick **Enable compositor on startup**.
 
-### The overlay shows but I can't click anything
+</details>
+
+<br>
+
+<details>
+<summary>The overlay shows but I can't click anything</summary>
 
 The window couldn't be made click-through. This is a window manager/compositor limitation.
 
-### The overlay doesn't show up
+</details>
+
+<br>
+
+<details>
+<summary>The overlay doesn't show up</summary>
 
 Your window manager doesn't support positioning or resizing windows.
 
-### The overlay isn't on top of other windows
+</details>
+
+<br>
+
+<details>
+<summary>The overlay isn't on top of other windows</summary>
 
 Your window manager doesn't support always-on-top windows.
+
+</details>

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ Each release contains the `deadlocked` binary and `setup.sh`.
 This creates a `uinput` group, adds your user to it, and installs a udev rule.
 You only need to do this once, even when updating to newer versions.
 
-**Run:**
+## Running
 
 ```bash
 ./deadlocked

--- a/readme.md
+++ b/readme.md
@@ -20,8 +20,8 @@ Each release contains the `deadlocked` binary and `setup.sh`.
 
 ```bash
 ./setup.sh
-# Restart your machine (required)
 ```
+> **Restart your machine (required)**
 
 This creates a `uinput` group, adds your user to it, and installs a udev rule.
 You only need to do this once, even when updating to newer versions.

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
+
 UDEV_RULE_FILE="/etc/udev/rules.d/99-uinput.rules"
 UINPUT_GROUP="uinput"
 CURRENT_USER=$(whoami)
+
 git config core.hooksPath .hooks
 
 sudo modprobe uinput
@@ -10,9 +12,10 @@ echo 'KERNEL=="uinput", MODE="0660", GROUP="uinput", TAG+="uaccess"' | sudo tee 
 echo "created udev file: $UDEV_RULE_FILE"
 
 if ! getent group "$UINPUT_GROUP" > /dev/null; then
-    sudo groupadd "$UINPUT_GROUP"
-    echo "created group $UINPUT_GROUP"
+  sudo groupadd "$UINPUT_GROUP"
+  echo "created group $UINPUT_GROUP"
 fi
+
 sudo usermod -aG "$UINPUT_GROUP" "$CURRENT_USER"
 echo "added user $CURRENT_USER to group $UINPUT_GROUP"
 
@@ -24,13 +27,23 @@ echo "reloaded udev rules"
 echo "uinput" | sudo tee /etc/modules-load.d/uinput.conf > /dev/null
 
 if [ "$XDG_CURRENT_DESKTOP" = "Hyprland" ]; then
-    echo "detected Hyprland as window manager"
-    RULE="windowrule = no_blur 1, match:title ^(deadlocked_overlay)$"
-    CONF_FILE="$HOME/.config/hypr/hyprland.conf"
-    if grep -Fxq "$RULE" "$CONF_FILE"; then
-        echo "deadlocked_overlay windowrule has already been added, skipping"
-    else
-        echo "$RULE" >> "$CONF_FILE"
-        echo "added windowrule to Hyprland"
-    fi
+  echo "detected Hyprland as window manager"
+
+  RULE='
+-- deadlocked_overlay no_blur windowrule
+hl.window_rule({
+    match = {
+        title = "^(deadlocked_overlay)$",
+    },
+    no_blur = true,
+})'
+
+  LUA_FILE="$HOME/.config/hypr/hyprland.lua"
+
+  if grep -Fq 'title = "^(deadlocked_overlay)$"' "$LUA_FILE"; then
+    echo "deadlocked_overlay no_blur windowrule has already been added, skipping"
+  else
+    echo "$RULE" >> "$LUA_FILE"
+    echo "added no_blur windowrule to Hyprland"
+  fi
 fi


### PR DESCRIPTION
# what i changed
- ofc the `setup.sh` change the .conf config to new .lua config syntax and file path
- rename `os-setup.md` to `compatibility.md`, added the hyprland syntax for legacy .conf there and formate it a bit
- change link to `os-setup.md` to `compatibility.md` in `readme.md`, and formate it a bit too
- made the faqs in `readme.md` collapsable

hope you like it!

> i deleted the old PR accidently new to github (still learning), sorry