### PR TITLE
Restore Nix flake for local builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786098110,
+        "narHash": "sha256-shi1tjDhCGGd0kIgVPNY03V8NBWSTzhMSFDb7IqSoec=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "afb4584a80bbf779ce0f691509ff902d188c2b3d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  description = "deadlocked dev shell for Nix users";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    systems.url = "github:nix-systems/default-linux";
+  };
+
+  outputs = inputs @ {
+    self,
+    nixpkgs,
+    systems,
+    ...
+  }: let
+    # Build outputs for each system
+    eachSystem = nixpkgs.lib.genAttrs (import systems);
+    pkgsFor = system:
+      import nixpkgs {
+        inherit system;
+        overlays = [];
+      };
+  in {
+    # Development shell
+    devShells = eachSystem (system: {
+      default = (pkgsFor system).callPackage ./nix/shell.nix {};
+    });
+
+    # Code formatter
+    formatter.x86_64-linux = inputs.nixpkgs.legacyPackages.x86_64-linux.alejandra;
+  };
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,35 @@
+{pkgs}: let
+  # Graphics and X11 libraries
+  baseLibs = with pkgs; [
+    libx11
+    libxcursor
+    libxkbcommon
+    libGL
+    libxi
+  ];
+in
+  pkgs.mkShell {
+    name = "deadlocked-dev-shell";
+
+    nativeBuildInputs = with pkgs;
+      [
+        # Rust toolchain
+        cargo
+        rustc
+        scdoc
+        # Runtime dependencies
+        wayland
+        # Development tools
+        cargo-audit
+        cargo-deny
+        pkg-config
+        clippy
+        rust-analyzer
+        rustfmt
+        strace
+        gdb
+      ]
+      ++ baseLibs;
+
+    LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath baseLibs;
+  }


### PR DESCRIPTION
## Summary
- Restore `flake.nix`, `flake.lock`, and `nix/shell.nix` removed during the radar refactor
- Refresh the lock to current nixpkgs-unstable so `direnv` / `nix develop` works again
- Verified `nix develop -c cargo build --release` succeeds

## Test plan
- [ ] `direnv allow` (or `nix develop`) enters the shell with `rustc`/`cargo`
- [ ] `cargo build --release` completes in the flake shell
- [ ] Compatibility docs still match the restored flake layout