### PR TITLE
fix Hyprland GUI mapping, map resets, and ESP heuristics

### DIFF
--- a/cheat/src/cs2/entity/player.rs
+++ b/cheat/src/cs2/entity/player.rs
@@ -495,20 +495,16 @@ impl Player {
         let current_weapon = self.weapon(cs2);
 
         let is_jumping = velocity.z > 100.0 && self.is_in_air(cs2);
-        // knife walking speed is 250 units/s
-        let is_walking = speed > 100.0;
         let is_standing = speed < 10.0;
-
-        // check for scoping (only for snipers)
         let is_scoped = self.is_scoped(cs2);
 
-        if is_walking || is_standing {
+        if is_standing && !is_jumping {
             return None;
         }
 
         if is_scoped && current_weapon.weapon_class() == WeaponClass::Sniper {
             Some(SoundType::Weapon)
-        } else if speed > 150.0 || is_jumping || velocity.z < -200.0 {
+        } else if speed > 130.0 || is_jumping || velocity.z < -200.0 {
             Some(SoundType::Footstep)
         } else {
             None

--- a/cheat/src/cs2/features/esp_toggle.rs
+++ b/cheat/src/cs2/features/esp_toggle.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::{Config, aim::KeyMode},
-    cs2::CS2,
+    cs2::{CS2, key_codes::KeyCode},
 };
 
 pub struct EspToggle {
@@ -16,6 +16,9 @@ impl Default for EspToggle {
 impl CS2 {
     pub fn esp_toggle(&mut self, config: &Config) {
         let hotkey = config.player.esp_hotkey;
+        if hotkey == KeyCode::None {
+            return;
+        }
 
         Self::check_hotkey(&self.input, KeyMode::Toggle, hotkey, &mut self.esp.active);
     }

--- a/cheat/src/cs2/mod.rs
+++ b/cheat/src/cs2/mod.rs
@@ -80,6 +80,8 @@ impl CS2 {
         };
         utils::info!("offsets found");
 
+        self.reset_world_state();
+        self.current_bvh.clear();
         self.is_valid = true;
     }
 
@@ -93,8 +95,8 @@ impl CS2 {
         self.input.update(&self.process, &self.offsets);
 
         if self.last_cache.elapsed() > Duration::from_millis(200) {
+            self.check_map();
             self.cache_entities();
-            self.check_bvh();
             self.last_cache = Instant::now();
         }
 
@@ -384,15 +386,41 @@ impl CS2 {
         }
     }
 
-    fn check_bvh(&mut self) {
+    fn check_map(&mut self) {
         let current_map = self.current_map();
+        let map_ready = !current_map.is_empty() && current_map != "<empty>";
+
+        if !map_ready {
+            if !self.current_bvh.is_empty() {
+                utils::info!("map unloading, clearing world state");
+                self.reset_world_state();
+                self.current_bvh.clear();
+            }
+            return;
+        }
+
         if current_map != self.current_bvh {
+            utils::info!("map changed to {current_map}, resetting world state");
+            self.reset_world_state();
             self.bvh = read_map(self);
             if self.bvh.is_some() {
                 utils::info!("loaded bvh for {current_map}");
-                self.current_bvh = current_map;
             }
+            self.current_bvh = current_map;
         }
+    }
+
+    fn reset_world_state(&mut self) {
+        self.players.clear();
+        self.dead_players.clear();
+        self.entities.clear();
+        self.planted_c4 = None;
+        self.bvh = None;
+        self.target.reset();
+    }
+
+    pub fn set_esp_active(&mut self, active: bool) {
+        self.esp.active = active;
     }
 
     fn check_hotkey(input: &Input, mode: KeyMode, key: KeyCode, active: &mut bool) -> bool {

--- a/cheat/src/font.rs
+++ b/cheat/src/font.rs
@@ -69,7 +69,7 @@ impl Font {
 
 impl Display for Font {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(
+        write!(
             f,
             "{}",
             match self {

--- a/cheat/src/game.rs
+++ b/cheat/src/game.rs
@@ -54,7 +54,11 @@ impl GameManager {
         loop {
             let start = Instant::now();
             while let Ok(message) = self.channel.try_receive() {
-                self.config = *message.0;
+                let new_config = *message.0;
+                if new_config.player.enabled && !self.config.player.enabled {
+                    self.cs2.set_esp_active(true);
+                }
+                self.config = new_config;
             }
 
             let mut is_valid = self.cs2.is_valid();

--- a/cheat/src/ui/app.rs
+++ b/cheat/src/ui/app.rs
@@ -62,6 +62,9 @@ pub struct AppState {
     pub update_popup: bool,
     pub overlay_egui: Option<egui::Context>,
     pub gui_focused: bool,
+    /// Number of GUI frames presented while mapping the settings window.
+    /// Hyprland/niri will not map an XWayland window that never presents.
+    pub gui_present_frames: u8,
 
     pub radar_status: RadarStatus,
 }
@@ -125,6 +128,7 @@ impl AppState {
             update_popup,
             overlay_egui: None,
             gui_focused: true,
+            gui_present_frames: 0,
             radar_status: RadarStatus::Disabled,
         }
     }
@@ -157,6 +161,9 @@ impl App {
 
         self.state.display_scale = gui.window().scale_factor() as f32;
         self.state.overlay_egui = Some(overlay.egui().clone());
+        self.state.gui_focused = true;
+        self.state.gui_present_frames = 0;
+        gui.window().set_visible(true);
         utils::info!("detected display scale: {}", self.state.display_scale);
 
         self.gui = Some(gui);

--- a/cheat/src/ui/gui/mod.rs
+++ b/cheat/src/ui/gui/mod.rs
@@ -256,18 +256,29 @@ impl App {
         let overlay = self.overlay.as_mut().unwrap();
         let state = &mut self.state;
 
-        if state.gui_focused {
-            if let Err(err) = gui.make_current() {
-                utils::error!("could not make gui window current: {err}");
-                return;
-            }
-            gui.run(|ui| state.gui(ui));
-            gui.clear();
-            gui.paint();
+        // Present a few frames even if unfocused so XWayland compositors (Hyprland,
+        // niri) actually map the settings window. After that, skip presents while
+        // unfocused so an obscured GUI cannot stall/assert in eglX11SwapBuffers.
+        const GUI_MAP_FRAMES: u8 = 15;
+        let present_gui = state.gui_focused || state.gui_present_frames < GUI_MAP_FRAMES;
 
-            if let Err(err) = gui.swap_buffers() {
-                utils::error!("could not swap gui window buffers: {err}");
-                return;
+        if present_gui {
+            gui.window().set_visible(true);
+            match gui.make_current() {
+                Err(err) => {
+                    utils::error!("could not make gui window current: {err}");
+                }
+                Ok(()) => {
+                    gui.run(|ui| state.gui(ui));
+                    gui.clear();
+                    gui.paint();
+
+                    if let Err(err) = gui.swap_buffers() {
+                        utils::error!("could not swap gui window buffers: {err}");
+                    } else if state.gui_present_frames < GUI_MAP_FRAMES {
+                        state.gui_present_frames = state.gui_present_frames.saturating_add(1);
+                    }
+                }
             }
         }
 

--- a/cheat/src/ui/window_context.rs
+++ b/cheat/src/ui/window_context.rs
@@ -43,6 +43,9 @@ impl WindowContext {
         } else {
             winit::window::WindowAttributes::default()
                 .with_inner_size(winit::dpi::LogicalSize::new(750, 450))
+                .with_min_inner_size(winit::dpi::LogicalSize::new(400, 300))
+                .with_visible(true)
+                .with_resizable(true)
                 .with_title("deadlocked")
         };
 


### PR DESCRIPTION
## Summary
- **Hyprland / niri settings GUI**: present the settings window for the first few frames even while unfocused so XWayland actually maps it, then skip unfocused presents (avoids the idle/`eglX11SwapBuffers` stall). Also set the GUI window visible/resizable with a sane minimum size.
- **Map changes**: replace the old BVH-only refresh with a full world-state reset when the map unloads or changes, and clear state on attach. Stops stale players/entities/BVH from surviving across maps.
- **ESP toggle**: ignore `KeyCode::None` so a cleared hotkey cannot flip ESP; when ESP is re-enabled from config, force the feature active.
- **Sound ESP**: treat standing (and not jumping) as silent; adjust the footstep speed threshold so knife walk / crawl cases are less noisy.
- **Font combo**: use `write!` instead of `writeln!` so the font dropdown label does not include a trailing newline.

## Motivation
On Hyprland the settings window often never appeared (overlay-only). Map switches could leave wrong BVH/visibility state. Sound ESP and ESP hotkey edge cases produced false positives / stuck toggles.