### PR TITLE
add overlay radar and harden entity position reads

### DIFF
--- a/cheat/src/config/hud.rs
+++ b/cheat/src/config/hud.rs
@@ -1,7 +1,7 @@
 use egui::Color32;
 use serde::{Deserialize, Serialize};
 
-use super::text::OverlayTextConfig;
+use super::text::{OverlayTextConfig, TextPosition};
 
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -17,6 +17,7 @@ pub struct HudConfig {
     pub line_width: f32,
     pub debug: bool,
     pub overlay_text: OverlayTextConfig,
+    pub minimap: MinimapConfig,
 }
 
 impl Default for HudConfig {
@@ -33,6 +34,61 @@ impl Default for HudConfig {
             line_width: 2.0,
             debug: false,
             overlay_text: OverlayTextConfig::default(),
+            minimap: MinimapConfig::default(),
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct MinimapConfig {
+    pub enabled: bool,
+    pub size: f32,
+    pub range: f32,
+    pub position: TextPosition,
+    pub opacity: f32,
+    pub icon_size: f32,
+    pub rotate_with_view: bool,
+    pub show_names: bool,
+    pub show_bomb: bool,
+    pub show_teammates: bool,
+    pub show_smoke: bool,
+    pub show_molotov: bool,
+    pub show_rings: bool,
+    pub clamp_to_edge: bool,
+    pub background: Color32,
+    pub enemy_color: Color32,
+    pub teammate_color: Color32,
+    pub bomb_color: Color32,
+    pub local_color: Color32,
+    pub smoke_color: Color32,
+    pub molotov_color: Color32,
+}
+
+impl Default for MinimapConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            size: 220.0,
+            range: 2500.0,
+            position: TextPosition::TopRight,
+            opacity: 0.82,
+            icon_size: 7.0,
+            rotate_with_view: true,
+            show_names: false,
+            show_bomb: true,
+            show_teammates: true,
+            show_smoke: true,
+            show_molotov: true,
+            show_rings: true,
+            clamp_to_edge: true,
+            background: Color32::from_rgba_unmultiplied(6, 10, 16, 210),
+            enemy_color: Color32::from_rgb(255, 72, 72),
+            teammate_color: Color32::from_rgb(80, 196, 255),
+            bomb_color: Color32::from_rgb(255, 196, 48),
+            local_color: Color32::from_rgb(255, 255, 255),
+            smoke_color: Color32::from_rgb(170, 180, 190),
+            molotov_color: Color32::from_rgb(255, 110, 40),
         }
     }
 }

--- a/cheat/src/config/player.rs
+++ b/cheat/src/config/player.rs
@@ -58,6 +58,7 @@ pub struct PlayerConfig {
     pub weapon_icon: bool,
     pub tags: bool,
     pub visible_only: bool,
+    pub behind_players: BehindPlayersConfig,
     pub sound: SoundConfig,
 }
 
@@ -81,7 +82,28 @@ impl Default for PlayerConfig {
             weapon_icon: true,
             tags: true,
             visible_only: false,
+            behind_players: BehindPlayersConfig::default(),
             sound: SoundConfig::default(),
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct BehindPlayersConfig {
+    pub enabled: bool,
+    pub color: Color32,
+    pub visible_color: Color32,
+    pub size: f32,
+}
+
+impl Default for BehindPlayersConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            color: Color32::from_rgb(255, 196, 0),
+            visible_color: Color32::from_rgb(80, 220, 120),
+            size: 22.0,
         }
     }
 }

--- a/cheat/src/cs2/entity/base_entity.rs
+++ b/cheat/src/cs2/entity/base_entity.rs
@@ -18,6 +18,10 @@ impl BaseEntity {
         Self { handle }
     }
 
+    fn valid_ptr(ptr: usize) -> bool {
+        ptr != 0 && ptr >> 48 == 0
+    }
+
     pub fn health(&self, cs2: &CS2) -> i32 {
         cs2.process.read(self.handle + cs2.offsets.entity.health)
     }
@@ -38,13 +42,25 @@ impl BaseEntity {
     }
 
     pub fn game_scene_node(&self, cs2: &CS2) -> usize {
-        cs2.process
-            .read(self.handle + cs2.offsets.entity.game_scene_node)
+        let node = cs2
+            .process
+            .read::<usize>(self.handle + cs2.offsets.entity.game_scene_node);
+        if Self::valid_ptr(node) { node } else { 0 }
     }
 
     pub fn position(&self, cs2: &CS2) -> Vec3 {
-        cs2.process
-            .read(self.game_scene_node(cs2) + cs2.offsets.game_scene_node.origin)
+        let node = self.game_scene_node(cs2);
+        if node == 0 {
+            return Vec3::ZERO;
+        }
+        let Some(addr) = node.checked_add(cs2.offsets.game_scene_node.origin) else {
+            return Vec3::ZERO;
+        };
+        cs2.process.read(addr)
+    }
+
+    pub fn has_valid_position(&self, cs2: &CS2) -> bool {
+        self.game_scene_node(cs2) != 0
     }
 
     pub fn collision_bounds(&self, cs2: &CS2) -> (Vec3, Vec3) {

--- a/cheat/src/cs2/entity/inferno.rs
+++ b/cheat/src/cs2/entity/inferno.rs
@@ -24,6 +24,10 @@ impl Inferno {
         }
     }
 
+    pub fn controller_valid(&self, cs2: &CS2) -> bool {
+        self.controller.has_valid_position(cs2)
+    }
+
     pub fn is_burning(&self, cs2: &CS2) -> bool {
         cs2.process
             .read::<u8>(*self.controller + cs2.offsets.inferno.is_burning)

--- a/cheat/src/cs2/entity/molotov.rs
+++ b/cheat/src/cs2/entity/molotov.rs
@@ -22,6 +22,10 @@ impl Molotov {
         }
     }
 
+    pub fn controller_valid(&self, cs2: &CS2) -> bool {
+        self.controller.has_valid_position(cs2)
+    }
+
     pub fn is_incendiary(&self, cs2: &CS2) -> bool {
         cs2.process
             .read::<u8>(*self.controller + cs2.offsets.molotov.is_incendiary)

--- a/cheat/src/cs2/entity/smoke.rs
+++ b/cheat/src/cs2/entity/smoke.rs
@@ -20,6 +20,10 @@ impl Smoke {
         grenade_info(self.controller, "Smoke", cs2)
     }
 
+    pub fn controller_valid(&self, cs2: &CS2) -> bool {
+        self.controller.has_valid_position(cs2)
+    }
+
     pub fn disable(&self, cs2: &CS2) {
         let disabled = cs2
             .process

--- a/cheat/src/cs2/mod.rs
+++ b/cheat/src/cs2/mod.rs
@@ -238,27 +238,59 @@ impl CS2 {
 
         data.entities.clear();
         for entity in &self.entities {
-            data.entities.push(match entity {
-                Entity::Weapon { weapon, entity } => EntityInfo::Weapon(WeaponInfo {
-                    weapon: weapon.clone(),
-                    position: Player::entity(**entity).position(self),
-                    ammo: (
-                        weapon_clip_ammo(**entity, self),
-                        weapon_reserve_ammo(**entity, self),
-                    ),
-                }),
-                Entity::Inferno(inferno) => EntityInfo::Inferno(inferno.info(self)),
-                Entity::Smoke(smoke) => EntityInfo::Smoke(smoke.info(self)),
-                Entity::Molotov(molotov) => EntityInfo::Molotov(molotov.info(self)),
+            let info = match entity {
+                Entity::Weapon { weapon, entity } => {
+                    if !entity.has_valid_position(self) {
+                        continue;
+                    }
+                    EntityInfo::Weapon(WeaponInfo {
+                        weapon: weapon.clone(),
+                        position: Player::entity(**entity).position(self),
+                        ammo: (
+                            weapon_clip_ammo(**entity, self),
+                            weapon_reserve_ammo(**entity, self),
+                        ),
+                    })
+                }
+                Entity::Inferno(inferno) => {
+                    if !inferno.controller_valid(self) {
+                        continue;
+                    }
+                    EntityInfo::Inferno(inferno.info(self))
+                }
+                Entity::Smoke(smoke) => {
+                    if !smoke.controller_valid(self) {
+                        continue;
+                    }
+                    EntityInfo::Smoke(smoke.info(self))
+                }
+                Entity::Molotov(molotov) => {
+                    if !molotov.controller_valid(self) {
+                        continue;
+                    }
+                    EntityInfo::Molotov(molotov.info(self))
+                }
                 Entity::Flashbang(entity) => {
+                    if !entity.has_valid_position(self) {
+                        continue;
+                    }
                     EntityInfo::Flashbang(grenade_info(*entity, "Flashbang", self))
                 }
                 Entity::HeGrenade(entity) => {
+                    if !entity.has_valid_position(self) {
+                        continue;
+                    }
                     EntityInfo::HeGrenade(grenade_info(*entity, "HE Grenade", self))
                 }
-                Entity::Decoy(entity) => EntityInfo::Decoy(grenade_info(*entity, "Decoy", self)),
+                Entity::Decoy(entity) => {
+                    if !entity.has_valid_position(self) {
+                        continue;
+                    }
+                    EntityInfo::Decoy(grenade_info(*entity, "Decoy", self))
+                }
                 Entity::Chicken(chicken) => EntityInfo::Chicken(chicken.info(self)),
-            });
+            };
+            data.entities.push(info);
         }
 
         data.weapon = local_player.weapon(self);

--- a/cheat/src/game.rs
+++ b/cheat/src/game.rs
@@ -1,4 +1,5 @@
 use std::{
+    panic::AssertUnwindSafe,
     sync::Arc,
     thread::sleep,
     time::{Duration, Instant},
@@ -72,9 +73,17 @@ impl GameManager {
                     self.send_message(UiMessage::Status(GameStatus::Working));
                     previous_status = GameStatus::Working;
                 }
-                self.cs2.run(&self.config, &mut self.mouse);
-                let mut data = self.data.lock();
-                self.cs2.data(&self.config, &mut data);
+                let tick = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                    self.cs2.run(&self.config, &mut self.mouse);
+                    let mut data = self.data.lock();
+                    self.cs2.data(&self.config, &mut data);
+                }));
+                if let Err(err) = tick {
+                    utils::error!("game tick panicked: {err:?}");
+                    self.cs2 = CS2::new();
+                    previous_status = GameStatus::NotStarted;
+                    self.send_message(UiMessage::Status(GameStatus::NotStarted));
+                }
             } else {
                 *self.data.lock() = Data::default();
             }

--- a/cheat/src/math.rs
+++ b/cheat/src/math.rs
@@ -74,6 +74,33 @@ pub fn world_to_screen(position: &Vec3, data: &Data) -> Option<egui::Pos2> {
     Some(egui::pos2(screen_position.x, screen_position.y))
 }
 
+/// Shortest yaw delta in degrees, in (-180, 180].
+#[allow(dead_code)]
+pub fn yaw_delta(view_yaw: f32, target_yaw: f32) -> f32 {
+    (target_yaw - view_yaw + 180.0).rem_euclid(360.0) - 180.0
+}
+
+#[allow(dead_code)]
+pub fn yaw_to_target(from: Vec3, to: Vec3) -> f32 {
+    let delta = to - from;
+    delta.y.atan2(delta.x).to_degrees()
+}
+
+/// CS2 yaw 0 looks along +X. Camera right in XY is `(sin(yaw), -cos(yaw))`.
+pub fn camera_basis_xy(yaw_degrees: f32) -> (Vec2, Vec2) {
+    let yaw = yaw_degrees.to_radians();
+    let forward = Vec2::new(yaw.cos(), yaw.sin());
+    let right = Vec2::new(yaw.sin(), -yaw.cos());
+    (right, forward)
+}
+
+/// `x` = camera right, `y` = camera forward.
+pub fn world_to_camera_xy(local: Vec3, world: Vec3, yaw_degrees: f32) -> Vec2 {
+    let (right, forward) = camera_basis_xy(yaw_degrees);
+    let delta = Vec2::new(world.x - local.x, world.y - local.y);
+    Vec2::new(delta.dot(right), delta.dot(forward))
+}
+
 fn weighted_average_component(
     history: &std::collections::VecDeque<Vec2>,
     component: impl Fn(&Vec2) -> f32,

--- a/cheat/src/ui/gui/helpers.rs
+++ b/cheat/src/ui/gui/helpers.rs
@@ -28,6 +28,13 @@ pub fn checkbox_hover(ui: &mut Ui, label: &str, hover_text: &str, value: &mut bo
         .changed()
 }
 
+pub fn reset_button(ui: &mut Ui) -> bool {
+    ui.add_space(4.0);
+    ui.button("Reset section")
+        .on_hover_text("Restore this section to defaults")
+        .clicked()
+}
+
 pub fn drag(ui: &mut Ui, label: &str, drag: DragValue) -> bool {
     ui.horizontal(|ui| {
         let res = ui.add(drag);

--- a/cheat/src/ui/gui/hud.rs
+++ b/cheat/src/ui/gui/hud.rs
@@ -3,7 +3,8 @@ use egui::{DragValue, Ui};
 use crate::ui::{
     app::AppState,
     gui::helpers::{
-        checkbox, collapsing_open, color_picker, combo_box, drag, scroll, text_settings_button,
+        checkbox, checkbox_hover, collapsing_open, color_picker, combo_box, drag, reset_button,
+        scroll, text_settings_button,
     },
 };
 
@@ -23,6 +24,12 @@ impl AppState {
                     "Crosshair Color",
                     &mut self.config.hud.sniper_crosshair.color,
                 ) {
+                    self.send_config_game();
+                }
+
+                if reset_button(ui) {
+                    self.config.hud.sniper_crosshair.color =
+                        crate::config::hud::CrosshairConfig::default().color;
                     self.send_config_game();
                 }
             });
@@ -91,6 +98,11 @@ impl AppState {
                 ) {
                     self.send_config_game();
                 }
+
+                if reset_button(ui) {
+                    self.config.hud.grenade_trails = crate::config::hud::TrailConfig::default();
+                    self.send_config_game();
+                }
             });
         });
     }
@@ -128,6 +140,207 @@ impl AppState {
                 }
                 text_settings_button(ui, &mut self.text_popup, "spectator_list");
             });
+
+            if reset_button(ui) {
+                let defaults = crate::config::hud::HudConfig::default();
+                self.config.hud.bomb_timer = defaults.bomb_timer;
+                self.config.hud.fov_circle = defaults.fov_circle;
+                self.config.hud.dropped_weapons = defaults.dropped_weapons;
+                self.config.hud.keybind_list = defaults.keybind_list;
+                self.config.hud.spectator_list = defaults.spectator_list;
+                self.send_config_game();
+            }
+        });
+
+        ui.collapsing("Minimap", |ui| {
+            if checkbox_hover(
+                ui,
+                "Enabled",
+                "In-game radar overlay (not the web radar)",
+                &mut self.config.hud.minimap.enabled,
+            ) {
+                self.send_config_game();
+            }
+
+            if drag(
+                ui,
+                "Size",
+                DragValue::new(&mut self.config.hud.minimap.size)
+                    .range(80.0..=420.0)
+                    .max_decimals(0)
+                    .speed(1.0),
+            ) {
+                self.send_config_game();
+            }
+
+            if drag(
+                ui,
+                "Range",
+                DragValue::new(&mut self.config.hud.minimap.range)
+                    .range(400.0..=8000.0)
+                    .max_decimals(0)
+                    .speed(25.0),
+            ) {
+                self.send_config_game();
+            }
+
+            if drag(
+                ui,
+                "Opacity",
+                DragValue::new(&mut self.config.hud.minimap.opacity)
+                    .range(0.2..=1.0)
+                    .max_decimals(2)
+                    .speed(0.01),
+            ) {
+                self.send_config_game();
+            }
+
+            if drag(
+                ui,
+                "Icon Size",
+                DragValue::new(&mut self.config.hud.minimap.icon_size)
+                    .range(3.0..=16.0)
+                    .max_decimals(1)
+                    .speed(0.1),
+            ) {
+                self.send_config_game();
+            }
+
+            if combo_box(
+                ui,
+                "minimap_pos",
+                "Position",
+                &mut self.config.hud.minimap.position,
+            ) {
+                self.send_config_game();
+            }
+
+            if checkbox_hover(
+                ui,
+                "Rotate With View",
+                "Keep your facing direction at the top of the radar",
+                &mut self.config.hud.minimap.rotate_with_view,
+            ) {
+                self.send_config_game();
+            }
+
+            if checkbox(
+                ui,
+                "Show Names",
+                &mut self.config.hud.minimap.show_names,
+            ) {
+                self.send_config_game();
+            }
+
+            if checkbox(
+                ui,
+                "Show Bomb",
+                &mut self.config.hud.minimap.show_bomb,
+            ) {
+                self.send_config_game();
+            }
+
+            if checkbox(
+                ui,
+                "Show Teammates",
+                &mut self.config.hud.minimap.show_teammates,
+            ) {
+                self.send_config_game();
+            }
+
+            if checkbox(
+                ui,
+                "Show Smoke",
+                &mut self.config.hud.minimap.show_smoke,
+            ) {
+                self.send_config_game();
+            }
+
+            if checkbox(
+                ui,
+                "Show Molotov",
+                &mut self.config.hud.minimap.show_molotov,
+            ) {
+                self.send_config_game();
+            }
+
+            if checkbox(
+                ui,
+                "Range Rings",
+                &mut self.config.hud.minimap.show_rings,
+            ) {
+                self.send_config_game();
+            }
+
+            if checkbox_hover(
+                ui,
+                "Clamp To Edge",
+                "Players outside range stay on the radar rim",
+                &mut self.config.hud.minimap.clamp_to_edge,
+            ) {
+                self.send_config_game();
+            }
+
+            if color_picker(
+                ui,
+                "Background",
+                &mut self.config.hud.minimap.background,
+            ) {
+                self.send_config_game();
+            }
+
+            if color_picker(
+                ui,
+                "Enemy Color",
+                &mut self.config.hud.minimap.enemy_color,
+            ) {
+                self.send_config_game();
+            }
+
+            if color_picker(
+                ui,
+                "Teammate Color",
+                &mut self.config.hud.minimap.teammate_color,
+            ) {
+                self.send_config_game();
+            }
+
+            if color_picker(
+                ui,
+                "Bomb Color",
+                &mut self.config.hud.minimap.bomb_color,
+            ) {
+                self.send_config_game();
+            }
+
+            if color_picker(
+                ui,
+                "Local Color",
+                &mut self.config.hud.minimap.local_color,
+            ) {
+                self.send_config_game();
+            }
+
+            if color_picker(
+                ui,
+                "Smoke Color",
+                &mut self.config.hud.minimap.smoke_color,
+            ) {
+                self.send_config_game();
+            }
+
+            if color_picker(
+                ui,
+                "Molotov Color",
+                &mut self.config.hud.minimap.molotov_color,
+            ) {
+                self.send_config_game();
+            }
+
+            if reset_button(ui) {
+                self.config.hud.minimap = crate::config::hud::MinimapConfig::default();
+                self.send_config_game();
+            }
         });
 
         ui.collapsing("Sniper Crosshair", |ui| {
@@ -165,6 +378,12 @@ impl AppState {
                     .max_decimals(1)
                     .speed(0.2),
             ) {
+                self.send_config_game();
+            }
+
+            if reset_button(ui) {
+                self.config.hud.sniper_crosshair =
+                    crate::config::hud::CrosshairConfig::default();
                 self.send_config_game();
             }
         });
@@ -211,6 +430,18 @@ impl AppState {
                 ui.label("Grenade Lineup");
                 text_settings_button(ui, &mut self.text_popup, "grenade_lineup");
             });
+
+            if reset_button(ui) {
+                let defaults = crate::config::hud::HudConfig::default();
+                self.config.hud.text_outline = defaults.text_outline;
+                self.config.hud.line_width = defaults.line_width;
+                self.config.font = crate::config::Config::default().font;
+                self.config.font.set(ui.ctx());
+                if let Some(ctx) = &self.overlay_egui {
+                    self.config.font.set(ctx);
+                }
+                self.send_config_game();
+            }
         });
 
         ui.collapsing("Advanced", |ui| {
@@ -223,6 +454,12 @@ impl AppState {
                 "FPS",
                 DragValue::new(&mut self.config.fps).range(30..=500),
             ) {
+                self.send_config_game();
+            }
+
+            if reset_button(ui) {
+                self.config.hud.debug = false;
+                self.config.fps = crate::config::Config::default().fps;
                 self.send_config_game();
             }
         });

--- a/cheat/src/ui/gui/player.rs
+++ b/cheat/src/ui/gui/player.rs
@@ -1,10 +1,13 @@
 use egui::{DragValue, Ui};
 
-use crate::ui::{
-    app::AppState,
-    gui::helpers::{
-        checkbox, checkbox_hover, collapsing_open, color_picker, combo_box, drag, keybind, scroll,
-        text_settings_button,
+use crate::{
+    config::player::{BehindPlayersConfig, PlayerConfig, SoundConfig},
+    ui::{
+        app::AppState,
+        gui::helpers::{
+            checkbox, checkbox_hover, collapsing_open, color_picker, combo_box, drag, keybind,
+            reset_button, scroll, text_settings_button,
+        },
     },
 };
 
@@ -36,6 +39,14 @@ impl AppState {
                 }
 
                 if color_picker(ui, "Skeleton", &mut self.config.player.skeleton_color) {
+                    self.send_config_game();
+                }
+
+                if reset_button(ui) {
+                    let defaults = PlayerConfig::default();
+                    self.config.player.box_visible_color = defaults.box_visible_color;
+                    self.config.player.box_invisible_color = defaults.box_invisible_color;
+                    self.config.player.skeleton_color = defaults.skeleton_color;
                     self.send_config_game();
                 }
             });
@@ -98,6 +109,64 @@ impl AppState {
             ) {
                 self.send_config_game();
             }
+
+            if reset_button(ui) {
+                let defaults = PlayerConfig::default();
+                let player = &mut self.config.player;
+                player.enabled = defaults.enabled;
+                player.chicken = defaults.chicken;
+                player.esp_hotkey = defaults.esp_hotkey;
+                player.show_friendlies = defaults.show_friendlies;
+                player.draw_box = defaults.draw_box;
+                player.box_mode = defaults.box_mode;
+                player.draw_skeleton = defaults.draw_skeleton;
+                player.head_circle = defaults.head_circle;
+                player.visible_only = defaults.visible_only;
+                self.send_config_game();
+            }
+        });
+
+        ui.collapsing("Behind Players", |ui| {
+            if checkbox_hover(
+                ui,
+                "Enabled",
+                "Show markers for enemies outside your view (behind, left, right)",
+                &mut self.config.player.behind_players.enabled,
+            ) {
+                self.send_config_game();
+            }
+
+            if drag(
+                ui,
+                "Size",
+                DragValue::new(&mut self.config.player.behind_players.size)
+                    .range(10.0..=48.0)
+                    .max_decimals(0)
+                    .speed(0.5),
+            ) {
+                self.send_config_game();
+            }
+
+            if color_picker(
+                ui,
+                "Hidden Color",
+                &mut self.config.player.behind_players.color,
+            ) {
+                self.send_config_game();
+            }
+
+            if color_picker(
+                ui,
+                "Visible Color",
+                &mut self.config.player.behind_players.visible_color,
+            ) {
+                self.send_config_game();
+            }
+
+            if reset_button(ui) {
+                self.config.player.behind_players = BehindPlayersConfig::default();
+                self.send_config_game();
+            }
         });
     }
 
@@ -151,6 +220,17 @@ impl AppState {
                 }
                 text_settings_button(ui, &mut self.text_popup, "player_tags");
             });
+
+            if reset_button(ui) {
+                let defaults = PlayerConfig::default();
+                let player = &mut self.config.player;
+                player.health_bar = defaults.health_bar;
+                player.armor_bar = defaults.armor_bar;
+                player.player_name = defaults.player_name;
+                player.weapon_icon = defaults.weapon_icon;
+                player.tags = defaults.tags;
+                self.send_config_game();
+            }
         });
 
         ui.collapsing("Sound ESP", |ui| {
@@ -239,6 +319,11 @@ impl AppState {
                     }
                 });
             });
+
+            if reset_button(ui) {
+                self.config.player.sound = SoundConfig::default();
+                self.send_config_game();
+            }
         });
     }
 }

--- a/cheat/src/ui/overlay/hud.rs
+++ b/cheat/src/ui/overlay/hud.rs
@@ -1,8 +1,11 @@
-use egui::{Color32, Painter, Pos2, Stroke, pos2, vec2};
-use shared::{Data, WeaponClass};
+use egui::{Align2, Color32, Painter, Pos2, Shape, Stroke, pos2, vec2};
+use shared::{Data, PlayerData, WeaponClass};
 
 use crate::{
-    config::aim::KeyMode, config::text::TextPosition, math::world_to_screen, ui::app::AppState,
+    config::aim::KeyMode,
+    config::text::TextPosition,
+    math::{world_to_camera_xy, world_to_screen},
+    ui::app::AppState,
 };
 
 impl AppState {
@@ -256,6 +259,223 @@ impl AppState {
             ],
             stroke,
         );
+    }
+
+    pub fn draw_minimap(&self, painter: &Painter, data: &Data) {
+        if !self.config.hud.minimap.enabled || !data.in_game {
+            return;
+        }
+
+        let cfg = self.config.hud.minimap.clone();
+        let visible_color = self.config.player.box_visible_color;
+        let size = cfg.size.max(80.0);
+        let range = cfg.range.max(1.0);
+        let pad = 12.0;
+        let origin = minimap_origin(
+            [data.window_size.x, data.window_size.y],
+            cfg.position,
+            size,
+            pad,
+        );
+        let rect = egui::Rect::from_min_size(origin, egui::vec2(size, size));
+        let center = rect.center();
+        let radius = size * 0.5 - 6.0;
+        let alpha = (cfg.opacity.clamp(0.15, 1.0) * 255.0) as u8;
+        let icon = cfg.icon_size.clamp(3.0, 16.0);
+
+        let bg = with_alpha(cfg.background, alpha);
+        painter.circle_filled(center, radius + 3.0, Color32::from_rgba_unmultiplied(0, 0, 0, 90));
+        painter.circle_filled(center, radius, bg);
+        painter.circle_stroke(
+            center,
+            radius,
+            Stroke::new(1.6, Color32::from_rgba_unmultiplied(180, 220, 255, 55)),
+        );
+        painter.circle_stroke(
+            center,
+            radius - 3.0,
+            Stroke::new(1.0, Color32::from_rgba_unmultiplied(255, 255, 255, 18)),
+        );
+
+        if cfg.show_rings {
+            for t in [0.33, 0.66] {
+                painter.circle_stroke(
+                    center,
+                    radius * t,
+                    Stroke::new(1.0, Color32::from_rgba_unmultiplied(255, 255, 255, 22)),
+                );
+            }
+        }
+
+        let tick = Color32::from_rgba_unmultiplied(255, 255, 255, 28);
+        painter.line_segment(
+            [pos2(center.x, center.y - radius + 8.0), pos2(center.x, center.y - 6.0)],
+            Stroke::new(1.0, tick),
+        );
+        painter.line_segment(
+            [pos2(center.x - 5.0, center.y), pos2(center.x + 5.0, center.y)],
+            Stroke::new(1.0, tick),
+        );
+
+        let local = data.local_player.position;
+        let yaw = data.view_angles.y;
+        let rotate = cfg.rotate_with_view;
+
+        let to_map = |world: glam::Vec3| -> Option<(Pos2, bool)> {
+            let cam = if rotate {
+                world_to_camera_xy(local, world, yaw)
+            } else {
+                glam::Vec2::new(world.x - local.x, world.y - local.y)
+            };
+            let mut sx = cam.x / range;
+            let mut sy = cam.y / range;
+            let len = (sx * sx + sy * sy).sqrt();
+            let mut on_edge = false;
+            if len > 1.0 {
+                if !cfg.clamp_to_edge {
+                    return None;
+                }
+                sx /= len;
+                sy /= len;
+                on_edge = true;
+            }
+            Some((pos2(center.x + sx * radius, center.y - sy * radius), on_edge))
+        };
+
+        let facing = |player_yaw: f32| -> egui::Vec2 {
+            let fwd = glam::Vec2::new(player_yaw.to_radians().cos(), player_yaw.to_radians().sin());
+            let mapped = if rotate {
+                let (right, forward) = crate::math::camera_basis_xy(yaw);
+                glam::Vec2::new(fwd.dot(right), fwd.dot(forward))
+            } else {
+                fwd
+            };
+            vec2(mapped.x, -mapped.y)
+        };
+
+        let draw_player = |player: &PlayerData, color: Color32, draw_name: bool| {
+            let Some((pos, on_edge)) = to_map(player.position) else {
+                return;
+            };
+            let dir = facing(player.rotation);
+            radar_arrow(painter, pos, dir, color, icon);
+            if on_edge {
+                painter.circle_stroke(pos, icon * 0.85, Stroke::new(1.0, color));
+            }
+            if draw_name && cfg.show_names && !player.name.is_empty() {
+                self.text_sized(
+                    painter,
+                    &player.name,
+                    pos2(pos.x, pos.y + icon + 1.0),
+                    Align2::CENTER_TOP,
+                    color,
+                    (icon * 1.35).clamp(8.0, 13.0),
+                );
+            }
+        };
+
+        for player in &data.players {
+            let color = if player.visible {
+                visible_color
+            } else {
+                cfg.enemy_color
+            };
+            draw_player(player, color, true);
+        }
+
+        if cfg.show_teammates {
+            for player in &data.friendlies {
+                draw_player(player, cfg.teammate_color, true);
+            }
+        }
+
+        if cfg.show_bomb && data.bomb.planted {
+            if let Some((pos, _)) = to_map(data.bomb.position) {
+                let half = icon * 0.7;
+                painter.rect_filled(
+                    egui::Rect::from_center_size(pos, egui::vec2(half * 2.0, half * 2.0)),
+                    1.5,
+                    cfg.bomb_color,
+                );
+            }
+        }
+
+        for entity in &data.entities {
+            match entity {
+                shared::EntityInfo::Smoke(info) if cfg.show_smoke => {
+                    if let Some((pos, _)) = to_map(info.position) {
+                        painter.circle_filled(pos, icon * 0.9, cfg.smoke_color);
+                        painter.circle_stroke(
+                            pos,
+                            icon * 1.35,
+                            Stroke::new(1.0, with_alpha(cfg.smoke_color, 140)),
+                        );
+                    }
+                }
+                shared::EntityInfo::Molotov(info) if cfg.show_molotov => {
+                    if let Some((pos, _)) = to_map(info.position) {
+                        painter.circle_filled(pos, icon * 0.85, cfg.molotov_color);
+                    }
+                }
+                shared::EntityInfo::Inferno(info) if cfg.show_molotov => {
+                    if let Some((pos, _)) = to_map(info.position) {
+                        painter.circle_filled(pos, icon * 1.1, cfg.molotov_color);
+                        painter.circle_stroke(
+                            pos,
+                            icon * 1.6,
+                            Stroke::new(1.2, with_alpha(cfg.molotov_color, 160)),
+                        );
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let local_dir = if rotate {
+            vec2(0.0, -1.0)
+        } else {
+            facing(yaw)
+        };
+        radar_arrow(painter, center, local_dir, cfg.local_color, icon * 1.15);
+        painter.circle_filled(center, 1.6, cfg.local_color);
+    }
+}
+
+fn radar_arrow(painter: &Painter, pos: Pos2, dir: egui::Vec2, color: Color32, size: f32) {
+    let len = dir.length();
+    let dir = if len < 0.001 {
+        vec2(0.0, -size)
+    } else {
+        dir / len * size
+    };
+    let perp = vec2(-dir.y, dir.x) * 0.48;
+    let tip = pos2(pos.x + dir.x, pos.y + dir.y);
+    let left = pos2(pos.x - dir.x * 0.65 + perp.x, pos.y - dir.y * 0.65 + perp.y);
+    let right = pos2(pos.x - dir.x * 0.65 - perp.x, pos.y - dir.y * 0.65 - perp.y);
+    painter.add(Shape::convex_polygon(
+        vec![tip, left, right],
+        color,
+        Stroke::NONE,
+    ));
+}
+
+fn with_alpha(color: Color32, alpha: u8) -> Color32 {
+    let [r, g, b, _] = color.to_srgba_unmultiplied();
+    Color32::from_rgba_unmultiplied(r, g, b, alpha)
+}
+
+fn minimap_origin(size: [f32; 2], position: TextPosition, map_size: f32, pad: f32) -> Pos2 {
+    let [w, h] = size;
+    match position {
+        TextPosition::TopLeft => pos2(pad, pad),
+        TextPosition::TopCenter => pos2((w - map_size) * 0.5, pad),
+        TextPosition::TopRight => pos2(w - map_size - pad, pad),
+        TextPosition::CenterLeft => pos2(pad, (h - map_size) * 0.5),
+        TextPosition::Center => pos2((w - map_size) * 0.5, (h - map_size) * 0.5),
+        TextPosition::CenterRight => pos2(w - map_size - pad, (h - map_size) * 0.5),
+        TextPosition::BottomLeft => pos2(pad, h - map_size - pad),
+        TextPosition::BottomCenter => pos2((w - map_size) * 0.5, h - map_size - pad),
+        TextPosition::BottomRight => pos2(w - map_size - pad, h - map_size - pad),
     }
 }
 

--- a/cheat/src/ui/overlay/mod.rs
+++ b/cheat/src/ui/overlay/mod.rs
@@ -57,6 +57,10 @@ impl AppState {
         self.draw_sniper_crosshair(&painter, data);
         self.draw_keybind_list(&painter, data);
         self.draw_spectator_list(&painter, data);
+        self.draw_minimap(&painter, data);
+        if data.esp_active {
+            self.draw_behind_players(&painter, data);
+        }
 
         if data.aimbot_active {
             let cat = &self.config.hud.overlay_text.status_text;

--- a/cheat/src/ui/overlay/player.rs
+++ b/cheat/src/ui/overlay/player.rs
@@ -9,7 +9,7 @@ use shared::{Bones, Data, PlayerData, SoundType};
 use crate::{
     config::player::{BoxMode, DrawMode},
     config::text::TextPosition,
-    math::{CYLINDER_SAMPLES, world_to_screen},
+    math::{CYLINDER_SAMPLES, world_to_camera_xy, world_to_screen},
     ui::app::AppState,
 };
 
@@ -502,6 +502,110 @@ impl AppState {
             points[left],
             points[right],
         ))
+    }
+
+    pub fn draw_behind_players(&self, painter: &Painter, data: &Data) {
+        if !self.config.player.behind_players.enabled || !data.in_game {
+            return;
+        }
+
+        let cfg = self.config.player.behind_players.clone();
+        let w = data.window_size.x;
+        let h = data.window_size.y;
+        if w < 32.0 || h < 32.0 {
+            return;
+        }
+
+        let pad = 28.0;
+        let y = h - pad;
+        let marker_size = cfg.size.max(10.0);
+
+        let draw_marker = |player: &PlayerData| {
+            let target = if player.head.length_squared() > 1.0 {
+                player.head
+            } else {
+                player.position
+            };
+            if world_to_screen(&target, data).is_some() {
+                return;
+            }
+
+            let cam = world_to_camera_xy(
+                data.local_player.position,
+                player.position,
+                data.view_angles.y,
+            );
+            let abs_x = cam.x.abs();
+            let abs_y = cam.y.abs().max(1.0);
+
+            // Behind → bottom edge. Left/right (including off-screen sides) → side edges.
+            let pos = if cam.y < 0.0 && abs_y >= abs_x {
+                let x = (w * 0.5
+                    + (cam.x / -cam.y).clamp(-1.0, 1.0) * (w * 0.5 - pad))
+                    .clamp(pad, w - pad);
+                pos2(x, y)
+            } else if cam.x < 0.0 {
+                let sy = (h * 0.5
+                    - (cam.y / abs_x).clamp(-1.0, 1.0) * (h * 0.35))
+                    .clamp(pad, h - pad);
+                pos2(pad, sy)
+            } else {
+                let sy = (h * 0.5
+                    - (cam.y / abs_x.max(1.0)).clamp(-1.0, 1.0) * (h * 0.35))
+                    .clamp(pad, h - pad);
+                pos2(w - pad, sy)
+            };
+
+            let color = if player.visible {
+                cfg.visible_color
+            } else {
+                cfg.color
+            };
+
+            let tip = if pos.x <= pad + 1.0 {
+                pos2(pos.x - 8.0, pos.y)
+            } else if pos.x >= w - pad - 1.0 {
+                pos2(pos.x + 8.0, pos.y)
+            } else {
+                pos2(pos.x, pos.y + 8.0)
+            };
+            let left = if tip.y > pos.y {
+                pos2(pos.x - 7.0, pos.y - 4.0)
+            } else if tip.x < pos.x {
+                pos2(pos.x + 4.0, pos.y - 7.0)
+            } else {
+                pos2(pos.x - 4.0, pos.y - 7.0)
+            };
+            let right = if tip.y > pos.y {
+                pos2(pos.x + 7.0, pos.y - 4.0)
+            } else if tip.x < pos.x {
+                pos2(pos.x + 4.0, pos.y + 7.0)
+            } else {
+                pos2(pos.x - 4.0, pos.y + 7.0)
+            };
+            painter.add(egui::Shape::convex_polygon(
+                vec![tip, left, right],
+                color,
+                Stroke::NONE,
+            ));
+            self.text_sized(
+                painter,
+                "!",
+                pos2(pos.x, pos.y - marker_size * 0.35),
+                egui::Align2::CENTER_BOTTOM,
+                color,
+                marker_size,
+            );
+        };
+
+        for player in &data.players {
+            draw_marker(player);
+        }
+        if self.config.player.show_friendlies {
+            for player in &data.friendlies {
+                draw_marker(player);
+            }
+        }
     }
 
     pub fn update_player_sounds(&mut self) {


### PR DESCRIPTION
## Summary
- **Overlay minimap (HUD → Minimap)**: circular radar with rotate-with-view, range rings, teammate/bomb/name options, icon size/opacity/colors, and **smoke / molotov / inferno** markers.
- **Behind / off-screen players**: markers for enemies outside the view frustum — behind on the bottom edge, left/right on the side edges — with separate **hidden** and **visible** colors.
- **Crash fix**: `BaseEntity::position` no longer does unchecked `game_scene_node + origin` adds. Invalid scene nodes are rejected; grenade/weapon entity dumps skip bad handles. Without this, reading smoke/molotov during detonate could `panic` (`attempt to add with overflow`) and freeze the UI because the game thread died.
- **Game loop**: catch panics in a tick, log them, and re-init CS2 state so the process stays alive.
- **Camera helpers** in `math.rs` for CS2 yaw → camera-right/forward (fixes left/right flip vs world axes).
- Per-section **Reset** on the related HUD/Player panels.

## Motivation
Testing smoke/molotov on the radar killed the game thread via overflow when `m_pGameSceneNode` was null/garbage. Separately, users wanted a usable in-game radar and correct off-screen indicators (not only behind, and not mirrored left/right).

## Notes
- This is the **in-process overlay radar**, not the web radar (`radar/` + `server/`).
- Independent of the Hyprland GUI mapping PR; both can merge in either order.