### PR TITLE
add update-check toggle and per-section setting resets

### DIFF
--- a/cheat/src/config/application.rs
+++ b/cheat/src/config/application.rs
@@ -10,11 +10,15 @@ pub static APP_CONFIG_PATH: LazyLock<PathBuf> = LazyLock::new(|| BASE_PATH.join(
 #[serde(default)]
 pub struct ApplicationConfig {
     pub first_launch: bool,
+    pub check_for_updates: bool,
 }
 
 impl Default for ApplicationConfig {
     fn default() -> Self {
-        Self { first_launch: true }
+        Self {
+            first_launch: true,
+            check_for_updates: true,
+        }
     }
 }
 
@@ -31,7 +35,6 @@ pub fn read_app_config() -> ApplicationConfig {
     config.unwrap_or_default()
 }
 
-#[allow(dead_code)]
 pub fn write_app_config(config: &ApplicationConfig) {
     let out = toml::to_string(&config).unwrap();
     let _ = std::fs::write(APP_CONFIG_PATH.as_path(), out);

--- a/cheat/src/ui/app.rs
+++ b/cheat/src/ui/app.rs
@@ -45,7 +45,6 @@ pub struct AppState {
     pub new_grenade: Grenade,
     pub current_grenade: Option<(String, usize)>,
 
-    #[allow(dead_code)]
     pub app_config: ApplicationConfig,
     pub config: Config,
     pub current_config: PathBuf,
@@ -97,8 +96,13 @@ impl AppState {
         let grenades = read_grenades();
         let app_config = read_app_config();
 
-        let update_status = crate::update::check();
-        let update_popup = matches!(update_status, crate::update::UpdateStatus::Available { .. });
+        let (update_status, update_popup) = if app_config.check_for_updates {
+            let status = crate::update::check();
+            let popup = matches!(status, crate::update::UpdateStatus::Available { .. });
+            (status, popup)
+        } else {
+            (crate::update::UpdateStatus::UpToDate, false)
+        };
 
         Self {
             channel_game,

--- a/cheat/src/ui/gui/aimbot.rs
+++ b/cheat/src/ui/gui/aimbot.rs
@@ -2,10 +2,16 @@ use egui::{DragValue, Ui};
 use shared::Bones;
 use strum::IntoEnumIterator as _;
 
-use crate::ui::{
-    app::AppState,
-    drag_range::DragRange,
-    gui::helpers::{checkbox, checkbox_hover, collapsing_open, combo_box, drag, keybind, scroll},
+use crate::{
+    config::aim::{AimbotConfig, RcsConfig, TriggerbotConfig},
+    ui::{
+        app::AppState,
+        drag_range::DragRange,
+        gui::helpers::{
+            checkbox, checkbox_hover, collapsing_open, combo_box, drag, keybind, reset_button,
+            scroll,
+        },
+    },
 };
 
 #[derive(PartialEq)]
@@ -69,6 +75,16 @@ impl AppState {
                 "Mode",
                 &mut self.weapon_config().aimbot.mode,
             ) {
+                self.send_config_game();
+            }
+
+            if reset_button(ui) {
+                let override_enabled = self.weapon_config().aimbot.enable_override;
+                self.weapon_config().aimbot = AimbotConfig {
+                    enable_override: override_enabled,
+                    ..AimbotConfig::default()
+                };
+                self.config.aim.aimbot_hotkey = crate::config::aim::AimConfig::default().aimbot_hotkey;
                 self.send_config_game();
             }
         });
@@ -155,6 +171,20 @@ impl AppState {
             ) {
                 self.send_config_game();
             }
+
+            if reset_button(ui) {
+                let defaults = AimbotConfig::default();
+                let aimbot = &mut self.weapon_config().aimbot;
+                aimbot.target_friendlies = defaults.target_friendlies;
+                aimbot.distance_adjusted_fov = defaults.distance_adjusted_fov;
+                aimbot.fov = defaults.fov;
+                aimbot.smooth = defaults.smooth;
+                aimbot.inertia = defaults.inertia;
+                aimbot.prediction_time = defaults.prediction_time;
+                aimbot.start_bullet = defaults.start_bullet;
+                aimbot.targeting_mode = defaults.targeting_mode;
+                self.send_config_game();
+            }
         });
 
         ui.collapsing("Checks", |ui| {
@@ -171,6 +201,14 @@ impl AppState {
                 "Flash Check",
                 &mut self.weapon_config().aimbot.flash_check,
             ) {
+                self.send_config_game();
+            }
+
+            if reset_button(ui) {
+                let defaults = AimbotConfig::default();
+                let aimbot = &mut self.weapon_config().aimbot;
+                aimbot.visibility_check = defaults.visibility_check;
+                aimbot.flash_check = defaults.flash_check;
                 self.send_config_game();
             }
         });
@@ -192,6 +230,11 @@ impl AppState {
                     }
                     self.send_config_game();
                 }
+            }
+
+            if reset_button(ui) {
+                self.weapon_config().aimbot.bones = AimbotConfig::default().bones;
+                self.send_config_game();
             }
         });
     }
@@ -262,6 +305,17 @@ impl AppState {
             ) {
                 self.send_config_game();
             }
+
+            if reset_button(ui) {
+                let override_enabled = self.weapon_config().triggerbot.enable_override;
+                self.weapon_config().triggerbot = TriggerbotConfig {
+                    enable_override: override_enabled,
+                    ..TriggerbotConfig::default()
+                };
+                self.config.aim.triggerbot_hotkey =
+                    crate::config::aim::AimConfig::default().triggerbot_hotkey;
+                self.send_config_game();
+            }
         });
 
         ui.collapsing("Checks\u{200b}", |ui| {
@@ -284,7 +338,7 @@ impl AppState {
             if checkbox_hover(
                 ui,
                 "Velocity Check",
-                "Only shoot if the player moves slower than the specified threshold",
+                "Only shoot if YOU move slower than the threshold",
                 &mut self.weapon_config().triggerbot.velocity_check,
             ) {
                 self.send_config_game();
@@ -296,6 +350,16 @@ impl AppState {
                 DragValue::new(&mut self.weapon_config().triggerbot.velocity_threshold)
                     .range(0..=5000),
             ) {
+                self.send_config_game();
+            }
+
+            if reset_button(ui) {
+                let defaults = TriggerbotConfig::default();
+                let trigger = &mut self.weapon_config().triggerbot;
+                trigger.flash_check = defaults.flash_check;
+                trigger.scope_check = defaults.scope_check;
+                trigger.velocity_check = defaults.velocity_check;
+                trigger.velocity_threshold = defaults.velocity_threshold;
                 self.send_config_game();
             }
         });
@@ -335,6 +399,15 @@ impl AppState {
                 })
                 .inner
             {
+                self.send_config_game();
+            }
+
+            if reset_button(ui) {
+                let override_enabled = self.weapon_config().rcs.enable_override;
+                self.weapon_config().rcs = RcsConfig {
+                    enable_override: override_enabled,
+                    ..RcsConfig::default()
+                };
                 self.send_config_game();
             }
         });

--- a/cheat/src/ui/gui/application.rs
+++ b/cheat/src/ui/gui/application.rs
@@ -1,7 +1,11 @@
 use egui::Ui;
 
 use crate::{
-    ui::{app::AppState, gui::helpers::open_url},
+    config::application::write_app_config,
+    ui::{
+        app::AppState,
+        gui::helpers::{checkbox, open_url},
+    },
     update::UpdateStatus,
 };
 
@@ -16,24 +20,45 @@ impl AppState {
 
             ui.separator();
 
-            match &self.update_status {
-                UpdateStatus::UpToDate => {
-                    ui.colored_label(crate::ui::color::Colors::GREEN, "Up to date");
+            if checkbox(
+                ui,
+                "Check for Updates",
+                &mut self.app_config.check_for_updates,
+            ) {
+                write_app_config(&self.app_config);
+                if !self.app_config.check_for_updates {
+                    self.update_status = UpdateStatus::UpToDate;
+                    self.update_popup = false;
                 }
-                UpdateStatus::Available { version, url } => {
-                    ui.colored_label(
-                        crate::ui::color::Colors::YELLOW,
-                        format!("Update available: {version}"),
-                    );
-                    if ui.link("Download").clicked() {
-                        open_url(url);
+            }
+
+            ui.separator();
+
+            if !self.app_config.check_for_updates {
+                ui.colored_label(
+                    crate::ui::color::Colors::YELLOW,
+                    "Update checks disabled",
+                );
+            } else {
+                match &self.update_status {
+                    UpdateStatus::UpToDate => {
+                        ui.colored_label(crate::ui::color::Colors::GREEN, "Up to date");
                     }
-                }
-                UpdateStatus::Error(err) => {
-                    ui.colored_label(
-                        crate::ui::color::Colors::RED,
-                        format!("Update check failed: {err}"),
-                    );
+                    UpdateStatus::Available { version, url } => {
+                        ui.colored_label(
+                            crate::ui::color::Colors::YELLOW,
+                            format!("Update available: {version}"),
+                        );
+                        if ui.link("Download").clicked() {
+                            open_url(url);
+                        }
+                    }
+                    UpdateStatus::Error(err) => {
+                        ui.colored_label(
+                            crate::ui::color::Colors::RED,
+                            format!("Update check failed: {err}"),
+                        );
+                    }
                 }
             }
         });

--- a/cheat/src/ui/gui/helpers.rs
+++ b/cheat/src/ui/gui/helpers.rs
@@ -28,6 +28,13 @@ pub fn checkbox_hover(ui: &mut Ui, label: &str, hover_text: &str, value: &mut bo
         .changed()
 }
 
+pub fn reset_button(ui: &mut Ui) -> bool {
+    ui.add_space(4.0);
+    ui.button("Reset section")
+        .on_hover_text("Restore this section to defaults")
+        .clicked()
+}
+
 pub fn drag(ui: &mut Ui, label: &str, drag: DragValue) -> bool {
     ui.horizontal(|ui| {
         let res = ui.add(drag);

--- a/cheat/src/ui/gui/unsafe.rs
+++ b/cheat/src/ui/gui/unsafe.rs
@@ -1,8 +1,11 @@
 use egui::{DragValue, Ui};
 
-use crate::ui::{
-    app::AppState,
-    gui::helpers::{collapsing_open, color_picker},
+use crate::{
+    config::r#unsafe::UnsafeConfig,
+    ui::{
+        app::AppState,
+        gui::helpers::{collapsing_open, color_picker, reset_button},
+    },
 };
 
 impl AppState {
@@ -46,6 +49,14 @@ impl AppState {
             if color_picker(ui, "Smoke Color", &mut self.config.misc.smoke_color) {
                 self.send_config_game();
             }
+
+            if reset_button(ui) {
+                let defaults = UnsafeConfig::default();
+                self.config.misc.no_smoke = defaults.no_smoke;
+                self.config.misc.change_smoke_color = defaults.change_smoke_color;
+                self.config.misc.smoke_color = defaults.smoke_color;
+                self.send_config_game();
+            }
         });
     }
 
@@ -72,6 +83,13 @@ impl AppState {
                 }
                 ui.label("Max Flash Alpha");
             });
+
+            if reset_button(ui) {
+                let defaults = UnsafeConfig::default();
+                self.config.misc.no_flash = defaults.no_flash;
+                self.config.misc.max_flash_alpha = defaults.max_flash_alpha;
+                self.send_config_game();
+            }
         });
     }
 
@@ -102,6 +120,13 @@ impl AppState {
                     self.send_config_game();
                 }
             });
+
+            if reset_button(ui) {
+                let defaults = UnsafeConfig::default();
+                self.config.misc.fov_changer = defaults.fov_changer;
+                self.config.misc.desired_fov = defaults.desired_fov;
+                self.send_config_game();
+            }
         });
     }
 }


### PR DESCRIPTION
## Summary
- **Application → Check for Updates**: optional opt-out stored in the app config (`~/.config/deadlocked/deadlocked.toml`). When off, skip the GitHub release request and suppress the update popup.
- **Reset section** buttons on Aimbot / Targeting / Checks / Bones / Triggerbot / Trigger checks / RCS, plus No Flash / FOV / Smokes under Unsafe.
- Shared `reset_button` helper for consistent UI.

## Motivation
Some users run offline or do not want the startup update prompt. Resetting an entire config file is heavy when only one panel drifted.

## Notes
- Defaults keep `check_for_updates = true` (current behavior).
- Overlay Minimap / Behind Players resets live in the overlay PR if that lands separately; this PR covers Aimbot + Unsafe + Application.