### PR TITLE
fix: write desired fov directly to camera services instead of controller

### DIFF
--- a/cheat/src/cs2/entity/player.rs
+++ b/cheat/src/cs2/entity/player.rs
@@ -536,7 +536,7 @@ impl Player {
             .read(camera_service + cs2.offsets.camera_services.fov);
         if current != 0 && current != value {
             cs2.process
-                .write(self.controller + cs2.offsets.controller.desired_fov, value);
+                .write(camera_service + cs2.offsets.camera_services.fov, value);
         }
     }
 }


### PR DESCRIPTION
Fixes #380. The previous code was trying to apply the new FOV value via the player controller which doesn't affect camera rendering in CS2. Changed it to write directly to camera services where the current FOV is read from