### PR TITLE
feat: add grenade lineup alignment keybind

### DIFF
--- a/cheat/src/config/aim.rs
+++ b/cheat/src/config/aim.rs
@@ -162,9 +162,30 @@ impl Default for TriggerbotConfig {
 
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(default)]
+pub struct GrenadeAlignConfig {
+    pub enabled: bool,
+    pub hotkey: KeyCode,
+    pub fov: f32,
+    pub smooth: f32,
+}
+
+impl Default for GrenadeAlignConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            hotkey: KeyCode::None,
+            fov: 10.0,
+            smooth: 25.0,
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct AimConfig {
     pub aimbot_hotkey: KeyCode,
     pub triggerbot_hotkey: KeyCode,
+    pub grenade_align: GrenadeAlignConfig,
     pub global: WeaponConfig,
     pub weapons: HashMap<Weapon, WeaponConfig>,
 }
@@ -179,6 +200,7 @@ impl Default for AimConfig {
         Self {
             aimbot_hotkey: KeyCode::Mouse5,
             triggerbot_hotkey: KeyCode::Mouse4,
+            grenade_align: GrenadeAlignConfig::default(),
             global: WeaponConfig::enabled(true),
             weapons,
         }

--- a/cheat/src/cs2/features/grenade_align.rs
+++ b/cheat/src/cs2/features/grenade_align.rs
@@ -1,0 +1,111 @@
+use glam::vec2;
+
+use crate::{
+    config::Config,
+    constants::cs2::GRENADES,
+    cs2::{CS2, entity::player::Player},
+    math::{angles_to_fov, vec2_clamp},
+    os::mouse::Mouse,
+    ui::grenades::Grenade,
+};
+
+#[derive(Default)]
+pub struct GrenadeAlign {
+    pub is_aligning: bool,
+}
+
+impl CS2 {
+    pub fn grenade_align(&mut self, config: &Config, mouse: &mut Mouse) -> bool {
+        let align_config = &config.aim.grenade_align;
+
+        if !align_config.enabled {
+            self.grenade_align.is_aligning = false;
+            return false;
+        }
+
+        if !self.input.is_key_pressed(align_config.hotkey) {
+            self.grenade_align.is_aligning = false;
+            return false;
+        }
+
+        let Some(local_player) = Player::local_player(self) else {
+            self.grenade_align.is_aligning = false;
+            return false;
+        };
+
+        if !local_player.is_valid(self) {
+            self.grenade_align.is_aligning = false;
+            return false;
+        }
+
+        let weapon = local_player.weapon(self);
+        if !GRENADES.contains(&weapon) {
+            self.grenade_align.is_aligning = false;
+            return false;
+        }
+
+        let current_map = self.current_map();
+        let Some(grenades) = self.grenades.get(&current_map) else {
+            self.grenade_align.is_aligning = false;
+            return false;
+        };
+
+        let player_position = local_player.position(self);
+        let view_angles = local_player.view_angles(self);
+
+        let mut best_grenade: Option<(&Grenade, f32)> = None;
+
+        const MAX_DISTANCE: f32 = 24.0;
+        for grenade in grenades {
+            if grenade.weapon != weapon {
+                continue;
+            }
+
+            let dist = (player_position - grenade.position).length();
+            if dist > MAX_DISTANCE {
+                continue;
+            }
+
+            let fov = angles_to_fov(&view_angles, &grenade.view_angles);
+            if fov > align_config.fov {
+                continue;
+            }
+
+            match best_grenade {
+                Some((_, best_fov)) if fov < best_fov => {
+                    best_grenade = Some((grenade, fov));
+                }
+                None => {
+                    best_grenade = Some((grenade, fov));
+                }
+                _ => {}
+            }
+        }
+
+        let Some((target_grenade, _)) = best_grenade else {
+            self.grenade_align.is_aligning = false;
+            return false;
+        };
+
+        let target_angle = target_grenade.view_angles;
+
+        let mut aim_angles = view_angles - target_angle;
+        if aim_angles.y < -180.0 {
+            aim_angles.y += 360.0;
+        }
+        vec2_clamp(&mut aim_angles);
+
+        let sensitivity = self.get_sensitivity() * local_player.fov_multiplier(self);
+
+        let smooth = (align_config.smooth + 1.0).clamp(1.0, 50.0);
+        let mouse_angles = vec2(
+            aim_angles.y / sensitivity * 45.45,
+            -aim_angles.x / sensitivity * 45.45,
+        ) / smooth;
+
+        mouse.move_rel(mouse_angles);
+
+        self.grenade_align.is_aligning = true;
+        true
+    }
+}

--- a/cheat/src/cs2/features/mod.rs
+++ b/cheat/src/cs2/features/mod.rs
@@ -1,6 +1,7 @@
 pub mod aimbot;
 pub mod esp_toggle;
 mod fov_changer;
+pub mod grenade_align;
 mod no_flash;
 pub mod rcs;
 pub mod triggerbot;

--- a/cheat/src/cs2/mod.rs
+++ b/cheat/src/cs2/mod.rs
@@ -28,7 +28,7 @@ use crate::{
     math::{angles_from_vector, vec2_clamp},
     os::{mouse::Mouse, process::Process},
     parser::{bvh::Bvh, read_map},
-    ui::grenades::{GrenadeList, read_grenades},
+    ui::grenades::GrenadeList,
 };
 
 pub mod bvh;
@@ -58,13 +58,16 @@ pub struct CS2 {
     esp: EspToggle,
     grenade_align: GrenadeAlign,
     grenades: GrenadeList,
-    last_grenades_read: Instant,
     weapon: Weapon,
     planted_c4: Option<PlantedC4>,
     last_cache: Instant,
 }
 
 impl CS2 {
+    pub fn set_grenades(&mut self, grenades: GrenadeList) {
+        self.grenades = grenades;
+    }
+
     pub fn is_valid(&self) -> bool {
         self.is_valid && self.process.is_valid()
     }
@@ -127,11 +130,6 @@ impl CS2 {
         self.triggerbot_shoot(mouse);
 
         self.find_target(config);
-
-        if self.last_grenades_read.elapsed() > Duration::from_secs(1) {
-            self.grenades = read_grenades();
-            self.last_grenades_read = Instant::now();
-        }
 
         if !self.aimbot(config, mouse) {
             self.rcs(config, mouse);
@@ -323,8 +321,7 @@ impl CS2 {
             trigger: Triggerbot::default(),
             esp: EspToggle::default(),
             grenade_align: GrenadeAlign::default(),
-            grenades: read_grenades(),
-            last_grenades_read: Instant::now(),
+            grenades: GrenadeList::default(),
             weapon: Weapon::default(),
             planted_c4: None,
             last_cache: Instant::now(),

--- a/cheat/src/cs2/mod.rs
+++ b/cheat/src/cs2/mod.rs
@@ -16,7 +16,10 @@ use crate::{
             player::Player,
             weapon::{weapon_clip_ammo, weapon_reserve_ammo},
         },
-        features::{aimbot::Aimbot, esp_toggle::EspToggle, rcs::Recoil, triggerbot::Triggerbot},
+        features::{
+            aimbot::Aimbot, esp_toggle::EspToggle, grenade_align::GrenadeAlign, rcs::Recoil,
+            triggerbot::Triggerbot,
+        },
         input::Input,
         key_codes::KeyCode,
         offsets::Offsets,
@@ -25,6 +28,7 @@ use crate::{
     math::{angles_from_vector, vec2_clamp},
     os::{mouse::Mouse, process::Process},
     parser::{bvh::Bvh, read_map},
+    ui::grenades::{GrenadeList, read_grenades},
 };
 
 pub mod bvh;
@@ -52,6 +56,9 @@ pub struct CS2 {
     aim: Aimbot,
     trigger: Triggerbot,
     esp: EspToggle,
+    grenade_align: GrenadeAlign,
+    grenades: GrenadeList,
+    last_grenades_read: Instant,
     weapon: Weapon,
     planted_c4: Option<PlantedC4>,
     last_cache: Instant,
@@ -121,9 +128,16 @@ impl CS2 {
 
         self.find_target(config);
 
+        if self.last_grenades_read.elapsed() > Duration::from_secs(1) {
+            self.grenades = read_grenades();
+            self.last_grenades_read = Instant::now();
+        }
+
         if !self.aimbot(config, mouse) {
             self.rcs(config, mouse);
         }
+
+        self.grenade_align(config, mouse);
     }
 
     pub fn data(&self, config: &Config, data: &mut Data) {
@@ -275,6 +289,7 @@ impl CS2 {
         } else {
             false
         };
+        data.grenade_align_active = self.input.is_key_pressed(config.aim.grenade_align.hotkey);
         data.esp_active = self.esp_enabled(config);
 
         data.view_matrix = self.process.read::<Mat4>(self.offsets.direct.view_matrix);
@@ -307,6 +322,9 @@ impl CS2 {
             aim: Aimbot::default(),
             trigger: Triggerbot::default(),
             esp: EspToggle::default(),
+            grenade_align: GrenadeAlign::default(),
+            grenades: read_grenades(),
+            last_grenades_read: Instant::now(),
             weapon: Weapon::default(),
             planted_c4: None,
             last_cache: Instant::now(),

--- a/cheat/src/game.rs
+++ b/cheat/src/game.rs
@@ -54,7 +54,10 @@ impl GameManager {
         loop {
             let start = Instant::now();
             while let Ok(message) = self.channel.try_receive() {
-                self.config = *message.0;
+                match message {
+                    GameMessage::Config(config) => self.config = *config,
+                    GameMessage::Grenades(grenades) => self.cs2.set_grenades(*grenades),
+                }
             }
 
             let mut is_valid = self.cs2.is_valid();

--- a/cheat/src/message.rs
+++ b/cheat/src/message.rs
@@ -3,7 +3,10 @@ use std::{fmt::Display, time::Duration};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::config::{Config, radar::RadarConfig};
+use crate::{
+    config::{Config, radar::RadarConfig},
+    ui::grenades::GrenadeList,
+};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq)]
 pub enum GameStatus {
@@ -21,7 +24,10 @@ impl Display for GameStatus {
 }
 
 #[derive(Clone)]
-pub struct GameMessage(pub Box<Config>);
+pub enum GameMessage {
+    Config(Box<Config>),
+    Grenades(Box<GrenadeList>),
+}
 
 #[derive(Clone)]
 pub enum UiMessage {

--- a/cheat/src/ui/app.rs
+++ b/cheat/src/ui/app.rs
@@ -144,6 +144,7 @@ impl App {
         };
         ret.send_config_game();
         ret.send_config_radar();
+        ret.send_grenades_game();
         ret
     }
 

--- a/cheat/src/ui/gui/config.rs
+++ b/cheat/src/ui/gui/config.rs
@@ -25,6 +25,7 @@ impl AppState {
                 if right.button("Refresh").clicked() {
                     self.available_configs = available_configs();
                     self.grenades = read_grenades();
+                    self.send_grenades_game();
                 }
 
                 right.horizontal(|right| {

--- a/cheat/src/ui/gui/grenade.rs
+++ b/cheat/src/ui/gui/grenade.rs
@@ -6,13 +6,46 @@ use crate::{
         app::AppState,
         color::Colors,
         grenades::{Grenade, write_grenades},
-        gui::helpers::{collapsing_open, scroll},
+        gui::helpers::{checkbox, collapsing_open, drag, keybind, scroll},
     },
 };
 
 impl AppState {
     pub fn grenade_settings(&mut self, ui: &mut Ui) {
         scroll(ui, "hud", |ui| {
+            let mut changed = false;
+
+            collapsing_open(ui, "Lineup Alignment", |ui| {
+                changed |= checkbox(ui, "Enabled", &mut self.config.aim.grenade_align.enabled);
+                changed |= keybind(
+                    ui,
+                    "grenade_align_hotkey",
+                    "Hotkey",
+                    &mut self.config.aim.grenade_align.hotkey,
+                );
+                changed |= drag(
+                    ui,
+                    "FOV",
+                    egui::DragValue::new(&mut self.config.aim.grenade_align.fov)
+                        .range(0.1..=180.0)
+                        .speed(0.1)
+                        .max_decimals(1)
+                        .suffix("°"),
+                );
+                changed |= drag(
+                    ui,
+                    "Smooth",
+                    egui::DragValue::new(&mut self.config.aim.grenade_align.smooth)
+                        .range(0.0..=50.0)
+                        .speed(0.1)
+                        .max_decimals(1),
+                );
+            });
+
+            if changed {
+                self.send_config_game();
+            }
+
             if self.current_grenade.is_some() {
                 self.edit_grenade(ui);
             } else {

--- a/cheat/src/ui/gui/grenade.rs
+++ b/cheat/src/ui/gui/grenade.rs
@@ -96,6 +96,7 @@ impl AppState {
 
         if should_write {
             write_grenades(&self.grenades);
+            self.send_grenades_game();
         }
     }
 
@@ -148,6 +149,7 @@ impl AppState {
 
                 grenade_list.push(new_grenade);
                 write_grenades(&self.grenades);
+                self.send_grenades_game();
             }
         });
     }
@@ -166,19 +168,26 @@ impl AppState {
                 return;
             };
 
+            let mut changed = false;
+
             ui.horizontal(|ui| {
-                ui.text_edit_singleline(&mut grenade.name);
+                changed |= ui.text_edit_singleline(&mut grenade.name).changed();
                 ui.label("Name");
             });
 
             ui.horizontal(|ui| {
-                ui.text_edit_multiline(&mut grenade.description);
+                changed |= ui.text_edit_multiline(&mut grenade.description).changed();
                 ui.label("Description");
             });
 
-            ui.checkbox(&mut grenade.modifiers.jump, "Jump");
-            ui.checkbox(&mut grenade.modifiers.duck, "Duck");
-            ui.checkbox(&mut grenade.modifiers.run, "Run");
+            changed |= ui.checkbox(&mut grenade.modifiers.jump, "Jump").changed();
+            changed |= ui.checkbox(&mut grenade.modifiers.duck, "Duck").changed();
+            changed |= ui.checkbox(&mut grenade.modifiers.run, "Run").changed();
+
+            if changed {
+                write_grenades(&self.grenades);
+                self.send_grenades_game();
+            }
         });
     }
 }

--- a/cheat/src/ui/gui/mod.rs
+++ b/cheat/src/ui/gui/mod.rs
@@ -42,8 +42,12 @@ pub enum Tab {
 
 impl AppState {
     pub fn send_config_game(&self) {
-        self.send_message_game(GameMessage(Box::new(self.config.clone())));
+        self.send_message_game(GameMessage::Config(Box::new(self.config.clone())));
         self.save();
+    }
+
+    pub fn send_grenades_game(&self) {
+        self.send_message_game(GameMessage::Grenades(Box::new(self.grenades.clone())));
     }
 
     pub fn send_message_game(&self, message: GameMessage) {

--- a/cheat/src/ui/overlay/hud.rs
+++ b/cheat/src/ui/overlay/hud.rs
@@ -120,6 +120,20 @@ impl AppState {
             triggerbot_color,
             cat.font_size,
         );
+
+        let grenade_align_color = if data.grenade_align_active {
+            Color32::GREEN
+        } else {
+            cat.color
+        };
+        self.text_sized(
+            painter,
+            format!("Grenade Align: {:?}", self.config.aim.grenade_align.hotkey),
+            position + vec2(0.0, cat.font_size * 2.0),
+            cat.align.to_align2(),
+            grenade_align_color,
+            cat.font_size,
+        );
     }
 
     pub fn draw_spectator_list(&self, painter: &Painter, data: &Data) {

--- a/cheat/src/ui/overlay/mod.rs
+++ b/cheat/src/ui/overlay/mod.rs
@@ -58,6 +58,7 @@ impl AppState {
         self.draw_keybind_list(&painter, data);
         self.draw_spectator_list(&painter, data);
 
+        let mut status_offset = 0.0;
         if data.aimbot_active {
             let cat = &self.config.hud.overlay_text.status_text;
             self.text_sized(
@@ -67,12 +68,13 @@ impl AppState {
                     [data.window_size.x, data.window_size.y],
                     cat.position,
                     8.0,
-                    8.0,
+                    8.0 + status_offset,
                 ),
                 cat.align.to_align2(),
                 cat.color,
                 cat.font_size,
             );
+            status_offset += cat.font_size;
         }
 
         if data.triggerbot_active {
@@ -84,7 +86,25 @@ impl AppState {
                     [data.window_size.x, data.window_size.y],
                     cat.position,
                     8.0,
-                    8.0 + cat.font_size,
+                    8.0 + status_offset,
+                ),
+                cat.align.to_align2(),
+                cat.color,
+                cat.font_size,
+            );
+            status_offset += cat.font_size;
+        }
+
+        if data.grenade_align_active {
+            let cat = &self.config.hud.overlay_text.status_text;
+            self.text_sized(
+                &painter,
+                "grenade align active",
+                hud::screen_anchor(
+                    [data.window_size.x, data.window_size.y],
+                    cat.position,
+                    8.0,
+                    8.0 + status_offset,
                 ),
                 cat.align.to_align2(),
                 cat.color,

--- a/readme.md
+++ b/readme.md
@@ -121,6 +121,7 @@ cargo run --release
 
 - Sniper crosshair
 - Bomb timer
+- Grenade lineup alignment
 
 ### Unsafe
 

--- a/shared/src/data.rs
+++ b/shared/src/data.rs
@@ -38,6 +38,8 @@ pub struct Data {
     #[serde(skip)]
     pub triggerbot_active: bool,
     #[serde(skip)]
+    pub grenade_align_active: bool,
+    #[serde(skip)]
     pub esp_active: bool,
 }
 


### PR DESCRIPTION
adds a keybind to smoothly align view angles to the nearest grenade lineup when standing on the throw spot and aiming within certain fov

- configurable hotkey, fov, and smoothness in grenades tab
- active on key hold while holding the matching granade (to the throw spot)
- hud keybind and status overlay indicators